### PR TITLE
Add trade history for Binance and Coinbase

### DIFF
--- a/coinbase/src/client/account.rs
+++ b/coinbase/src/client/account.rs
@@ -1,6 +1,9 @@
 use serde_json::json;
 
-use crate::model::{Account, CancelAllOrders, CancelOrder, Order, OrderRequest, OrderRequestMarketType, OrderRequestType, OrderSide, Fill};
+use crate::model::{
+    Account, CancelAllOrders, CancelOrder, Fill, Order, OrderRequest, OrderRequestMarketType,
+    OrderRequestType, OrderSide,
+};
 use crate::Coinbase;
 
 use shared::Result;

--- a/coinbase/src/client/account.rs
+++ b/coinbase/src/client/account.rs
@@ -1,7 +1,6 @@
-use crate::model::{
-    Account, CancelAllOrders, CancelOrder, Order, OrderRequest, OrderRequestMarketType,
-    OrderRequestType, OrderSide,
-};
+use serde_json::json;
+
+use crate::model::{Account, CancelAllOrders, CancelOrder, Order, OrderRequest, OrderRequestMarketType, OrderRequestType, OrderSide, Fill};
 use crate::Coinbase;
 
 use shared::Result;
@@ -135,6 +134,28 @@ impl Coinbase {
         let resp = self
             .transport
             .signed_delete::<_, _, ()>("/orders", Some(&params), None)
+            .await?;
+
+        Ok(resp)
+    }
+
+    pub async fn get_fills_for_order(&self, order_id: &str) -> Result<Vec<Fill>> {
+        let params = json! {{"order_id":order_id}};
+
+        let resp = self
+            .transport
+            .signed_get::<_, _>("/fills", Some(&params))
+            .await?;
+
+        Ok(resp)
+    }
+
+    pub async fn get_fills_for_product(&self, product_id: &str) -> Result<Vec<Fill>> {
+        let params = json! {{"product_id":product_id}};
+
+        let resp = self
+            .transport
+            .signed_get::<_, _>("/fills", Some(&params))
             .await?;
 
         Ok(resp)

--- a/coinbase/src/model/mod.rs
+++ b/coinbase/src/model/mod.rs
@@ -61,6 +61,23 @@ pub struct Trade {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Fill {
+    pub trade_id: u64,
+    pub product_id: String,
+    #[serde(with = "string_to_decimal")]
+    pub price: Decimal,
+    #[serde(with = "string_to_decimal")]
+    pub size: Decimal,
+    pub order_id: String,
+    pub created_at: String,
+    pub liquidity: String,
+    #[serde(with = "string_to_decimal")]
+    pub fee: Decimal,
+    pub settled: bool,
+    pub side: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Ticker {
     pub trade_id: i64,
     #[serde(with = "string_to_decimal")]

--- a/coinbase/tests/account.rs
+++ b/coinbase/tests/account.rs
@@ -110,6 +110,27 @@ async fn cancel_order() {
     println!("{:?}", resp);
 }
 
+#[tokio::test]
+async fn get_fills_for_order() {
+    let exchange = init();
+    let order = exchange
+        .limit_sell("BTC-USD", Decimal::new(2, 3), Decimal::new(10000, 0))
+        .await
+        .unwrap();
+    let resp = exchange
+        .get_fills_for_order(order.id.as_ref())
+        .await
+        .unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_fills_for_product() {
+    let exchange = init();
+    let resp = exchange.get_fills_for_product("BTC-USD").await.unwrap();
+    println!("{:?}", resp);
+}
+
 fn init() -> Coinbase {
     dotenv().ok();
     Coinbase::with_credential(

--- a/openlimits/src/binance/mod.rs
+++ b/openlimits/src/binance/mod.rs
@@ -3,10 +3,7 @@ use derive_more::{Deref, DerefMut};
 use shared::Result;
 
 use crate::exchange::Exchange;
-use crate::model::{
-    Asks, Balance, Bids, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest,
-    OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled,
-};
+use crate::model::{Asks, Balance, Bids, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Trade, TradeHistoryRequest, Side, Liquidity};
 use chrono::naive::NaiveDateTime;
 use chrono::{DateTime, Utc};
 use shared::errors::OpenLimitError;
@@ -28,7 +25,8 @@ impl Binance {
 
 #[async_trait]
 impl Exchange for Binance {
-    type IdType = u64;
+    type OrderIdType = u64;
+    type TradeIdType = u64;
 
     async fn order_book(&self, req: &OrderBookRequest) -> Result<OrderBookResponse> {
         self.get_depth(req.symbol.as_str(), None)
@@ -36,31 +34,31 @@ impl Exchange for Binance {
             .map(Into::into)
     }
 
-    async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::IdType>> {
+    async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>> {
         binance::Binance::limit_buy(self, &req.symbol, req.size, req.price)
             .await
             .map(Into::into)
     }
-    async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::IdType>> {
+    async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>> {
         binance::Binance::limit_sell(self, &req.symbol, req.size, req.price)
             .await
             .map(Into::into)
     }
 
-    async fn market_buy(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::IdType>> {
+    async fn market_buy(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::OrderIdType>> {
         binance::Binance::market_buy(self, &req.symbol, req.size)
             .await
             .map(Into::into)
     }
-    async fn market_sell(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::IdType>> {
+    async fn market_sell(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::OrderIdType>> {
         binance::Binance::market_sell(self, &req.symbol, req.size)
             .await
             .map(Into::into)
     }
     async fn cancel_order(
         &self,
-        req: &CancelOrderRequest<Self::IdType>,
-    ) -> Result<OrderCanceled<Self::IdType>> {
+        req: &CancelOrderRequest<Self::OrderIdType>,
+    ) -> Result<OrderCanceled<Self::OrderIdType>> {
         if let Some(pair) = req.pair.as_ref() {
             binance::Binance::cancel_order(self, pair.as_ref(), req.id)
                 .await
@@ -74,7 +72,7 @@ impl Exchange for Binance {
     async fn cancel_all_orders(
         &self,
         req: &CancelAllOrdersRequest,
-    ) -> Result<Vec<OrderCanceled<Self::IdType>>> {
+    ) -> Result<Vec<OrderCanceled<Self::OrderIdType>>> {
         if let Some(pair) = req.pair.as_ref() {
             binance::Binance::cancel_all_orders(self, pair.as_ref())
                 .await
@@ -85,7 +83,7 @@ impl Exchange for Binance {
             ))
         }
     }
-    async fn get_all_open_orders(&self) -> Result<Vec<Order<Self::IdType>>> {
+    async fn get_all_open_orders(&self) -> Result<Vec<Order<Self::OrderIdType>>> {
         binance::Binance::get_all_open_orders(self)
             .await
             .map(|v| v.into_iter().map(Into::into).collect())
@@ -95,6 +93,18 @@ impl Exchange for Binance {
         binance::Binance::get_account(self)
             .await
             .map(|v| v.balances.into_iter().map(Into::into).collect())
+    }
+
+    async fn get_trade_history(&self, req: &TradeHistoryRequest<Self::OrderIdType>) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>> {
+        if let Some(pair) = req.pair.as_ref() {
+            binance::Binance::trade_history(self, pair.as_ref())
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+        } else {
+            Err(OpenLimitError::MissingParameter(
+                "pair parameter is required.".to_string(),
+            ))
+        }
     }
 }
 
@@ -168,6 +178,32 @@ impl From<binance::model::Balance> for Balance {
             asset: balance.asset,
             free: balance.free,
             total: balance.locked + balance.free,
+        }
+    }
+}
+
+impl From<binance::model::TradeHistory> for Trade<u64, u64> {
+    fn from(trade_history: binance::model::TradeHistory) -> Self {
+        Self {
+            id: trade_history.id,
+            order_id: trade_history.order_id,
+            pair: trade_history.symbol,
+            price: trade_history.price,
+            qty: trade_history.qty,
+            fees: trade_history.commission,
+            side: match trade_history.is_buyer {
+                true => Side::Buy,
+                false => Side::Sell
+            },
+            liquidity: match trade_history.is_maker {
+                true => Some(Liquidity::Maker),
+                false => Some(Liquidity::Taker)
+            },
+            created_at: DateTime::from_utc(
+                NaiveDateTime::from_timestamp(
+                    (trade_history.time / 1_000) as i64,
+                    ((trade_history.time % 1_000) * 1_000_000) as u32),
+                Utc)
         }
     }
 }

--- a/openlimits/src/binance/mod.rs
+++ b/openlimits/src/binance/mod.rs
@@ -3,7 +3,11 @@ use derive_more::{Deref, DerefMut};
 use shared::Result;
 
 use crate::exchange::Exchange;
-use crate::model::{Asks, Balance, Bids, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Trade, TradeHistoryRequest, Side, Liquidity};
+use crate::model::{
+    Asks, Balance, Bids, CancelAllOrdersRequest, CancelOrderRequest, Liquidity,
+    OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse,
+    OrderCanceled, Side, Trade, TradeHistoryRequest,
+};
 use chrono::naive::NaiveDateTime;
 use chrono::{DateTime, Utc};
 use shared::errors::OpenLimitError;
@@ -95,7 +99,10 @@ impl Exchange for Binance {
             .map(|v| v.balances.into_iter().map(Into::into).collect())
     }
 
-    async fn get_trade_history(&self, req: &TradeHistoryRequest<Self::OrderIdType>) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>> {
+    async fn get_trade_history(
+        &self,
+        req: &TradeHistoryRequest<Self::OrderIdType>,
+    ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>> {
         if let Some(pair) = req.pair.as_ref() {
             binance::Binance::trade_history(self, pair.as_ref())
                 .await
@@ -193,17 +200,19 @@ impl From<binance::model::TradeHistory> for Trade<u64, u64> {
             fees: trade_history.commission,
             side: match trade_history.is_buyer {
                 true => Side::Buy,
-                false => Side::Sell
+                false => Side::Sell,
             },
             liquidity: match trade_history.is_maker {
                 true => Some(Liquidity::Maker),
-                false => Some(Liquidity::Taker)
+                false => Some(Liquidity::Taker),
             },
             created_at: DateTime::from_utc(
                 NaiveDateTime::from_timestamp(
                     (trade_history.time / 1_000) as i64,
-                    ((trade_history.time % 1_000) * 1_000_000) as u32),
-                Utc)
+                    ((trade_history.time % 1_000) * 1_000_000) as u32,
+                ),
+                Utc,
+            ),
         }
     }
 }

--- a/openlimits/src/coinbase/mod.rs
+++ b/openlimits/src/coinbase/mod.rs
@@ -3,7 +3,11 @@ use derive_more::{Deref, DerefMut};
 use shared::Result;
 
 use crate::exchange::Exchange;
-use crate::model::{Asks, Balance, Bids, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Trade, Side, Liquidity, TradeHistoryRequest};
+use crate::model::{
+    Asks, Balance, Bids, CancelAllOrdersRequest, CancelOrderRequest, Liquidity,
+    OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse,
+    OrderCanceled, Side, Trade, TradeHistoryRequest,
+};
 use chrono::DateTime;
 use shared::errors::OpenLimitError;
 
@@ -88,7 +92,10 @@ impl Exchange for Coinbase {
             .map(|v| v.into_iter().map(Into::into).collect())
     }
 
-    async fn get_trade_history(&self, req: &TradeHistoryRequest<Self::OrderIdType>) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>> {
+    async fn get_trade_history(
+        &self,
+        req: &TradeHistoryRequest<Self::OrderIdType>,
+    ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>> {
         if let Some(order_id) = req.order_id.as_ref() {
             coinbase::Coinbase::get_fills_for_order(self, order_id.as_ref())
                 .await
@@ -97,8 +104,7 @@ impl Exchange for Coinbase {
             coinbase::Coinbase::get_fills_for_product(self, product_id.as_ref())
                 .await
                 .map(|v| v.into_iter().map(Into::into).collect())
-        }
-        else {
+        } else {
             Err(OpenLimitError::MissingParameter(
                 "One of order_id or pair parameter is required.".to_string(),
             ))
@@ -174,16 +180,16 @@ impl From<coinbase::model::Fill> for Trade<u64, String> {
             fees: fill.fee,
             side: match fill.side.as_str() {
                 "buy" => Side::Buy,
-                _ => Side::Sell
+                _ => Side::Sell,
             },
             liquidity: match fill.liquidity.as_str() {
                 "M" => Some(Liquidity::Maker),
                 "T" => Some(Liquidity::Taker),
-                _ => None
+                _ => None,
             },
             created_at: DateTime::parse_from_rfc3339(&fill.created_at)
                 .unwrap()
-                .into()
+                .into(),
         }
     }
 }

--- a/openlimits/src/coinbase/mod.rs
+++ b/openlimits/src/coinbase/mod.rs
@@ -3,11 +3,9 @@ use derive_more::{Deref, DerefMut};
 use shared::Result;
 
 use crate::exchange::Exchange;
-use crate::model::{
-    Asks, Balance, Bids, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest,
-    OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled,
-};
+use crate::model::{Asks, Balance, Bids, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Trade, Side, Liquidity, TradeHistoryRequest};
 use chrono::DateTime;
+use shared::errors::OpenLimitError;
 
 #[derive(Deref, DerefMut)]
 pub struct Coinbase(coinbase::Coinbase);
@@ -31,29 +29,30 @@ impl Coinbase {
 
 #[async_trait]
 impl Exchange for Coinbase {
-    type IdType = String;
+    type OrderIdType = String;
+    type TradeIdType = u64;
     async fn order_book(&self, req: &OrderBookRequest) -> Result<OrderBookResponse> {
         self.book::<coinbase::model::BookRecordL2>(&req.symbol)
             .await
             .map(Into::into)
     }
-    async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::IdType>> {
+    async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>> {
         coinbase::Coinbase::limit_buy(self, &req.symbol, req.size, req.price)
             .await
             .map(Into::into)
     }
-    async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::IdType>> {
+    async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>> {
         coinbase::Coinbase::limit_sell(self, &req.symbol, req.size, req.price)
             .await
             .map(Into::into)
     }
 
-    async fn market_buy(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::IdType>> {
+    async fn market_buy(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::OrderIdType>> {
         coinbase::Coinbase::market_buy(self, &req.symbol, req.size)
             .await
             .map(Into::into)
     }
-    async fn market_sell(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::IdType>> {
+    async fn market_sell(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::OrderIdType>> {
         coinbase::Coinbase::market_sell(self, &req.symbol, req.size)
             .await
             .map(Into::into)
@@ -61,8 +60,8 @@ impl Exchange for Coinbase {
 
     async fn cancel_order(
         &self,
-        req: &CancelOrderRequest<Self::IdType>,
-    ) -> Result<OrderCanceled<Self::IdType>> {
+        req: &CancelOrderRequest<Self::OrderIdType>,
+    ) -> Result<OrderCanceled<Self::OrderIdType>> {
         coinbase::Coinbase::cancel_order(self, req.id.clone(), req.pair.as_deref())
             .await
             .map(Into::into)
@@ -71,13 +70,13 @@ impl Exchange for Coinbase {
     async fn cancel_all_orders(
         &self,
         req: &CancelAllOrdersRequest,
-    ) -> Result<Vec<OrderCanceled<Self::IdType>>> {
+    ) -> Result<Vec<OrderCanceled<Self::OrderIdType>>> {
         coinbase::Coinbase::cancel_all_orders(self, req.pair.as_deref())
             .await
             .map(|v| v.into_iter().map(Into::into).collect())
     }
 
-    async fn get_all_open_orders(&self) -> Result<Vec<Order<Self::IdType>>> {
+    async fn get_all_open_orders(&self) -> Result<Vec<Order<Self::OrderIdType>>> {
         coinbase::Coinbase::get_all_open_orders(self)
             .await
             .map(|v| v.into_iter().map(Into::into).collect())
@@ -87,6 +86,23 @@ impl Exchange for Coinbase {
         coinbase::Coinbase::get_account(self)
             .await
             .map(|v| v.into_iter().map(Into::into).collect())
+    }
+
+    async fn get_trade_history(&self, req: &TradeHistoryRequest<Self::OrderIdType>) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>> {
+        if let Some(order_id) = req.order_id.as_ref() {
+            coinbase::Coinbase::get_fills_for_order(self, order_id.as_ref())
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+        } else if let Some(product_id) = req.pair.as_ref() {
+            coinbase::Coinbase::get_fills_for_product(self, product_id.as_ref())
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+        }
+        else {
+            Err(OpenLimitError::MissingParameter(
+                "One of order_id or pair parameter is required.".to_string(),
+            ))
+        }
     }
 }
 
@@ -143,6 +159,31 @@ impl From<coinbase::model::Account> for Balance {
             asset: account.currency,
             free: account.available,
             total: account.balance,
+        }
+    }
+}
+
+impl From<coinbase::model::Fill> for Trade<u64, String> {
+    fn from(fill: coinbase::model::Fill) -> Self {
+        Self {
+            id: fill.trade_id,
+            order_id: fill.order_id,
+            pair: fill.product_id,
+            price: fill.price,
+            qty: fill.size,
+            fees: fill.fee,
+            side: match fill.side.as_str() {
+                "buy" => Side::Buy,
+                _ => Side::Sell
+            },
+            liquidity: match fill.liquidity.as_str() {
+                "M" => Some(Liquidity::Maker),
+                "T" => Some(Liquidity::Taker),
+                _ => None
+            },
+            created_at: DateTime::parse_from_rfc3339(&fill.created_at)
+                .unwrap()
+                .into()
         }
     }
 }

--- a/openlimits/src/exchange.rs
+++ b/openlimits/src/exchange.rs
@@ -2,10 +2,7 @@ use async_trait::async_trait;
 use derive_more::Constructor;
 use shared::Result;
 
-use crate::model::{
-    Balance, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest,
-    OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled,
-};
+use crate::model::{Balance, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Trade, TradeHistoryRequest};
 
 #[derive(Constructor)]
 pub struct OpenLimits<E: Exchange> {
@@ -20,69 +17,81 @@ impl<E: Exchange> OpenLimits<E> {
     pub async fn limit_buy(
         &self,
         req: impl AsRef<OpenLimitOrderRequest>,
-    ) -> Result<Order<E::IdType>> {
+    ) -> Result<Order<E::OrderIdType>> {
         self.exchange.limit_buy(req.as_ref()).await
     }
 
     pub async fn limit_sell(
         &self,
         req: impl AsRef<OpenLimitOrderRequest>,
-    ) -> Result<Order<E::IdType>> {
+    ) -> Result<Order<E::OrderIdType>> {
         self.exchange.limit_sell(req.as_ref()).await
     }
 
     pub async fn market_buy(
         &self,
         req: impl AsRef<OpenMarketOrderRequest>,
-    ) -> Result<Order<E::IdType>> {
+    ) -> Result<Order<E::OrderIdType>> {
         self.exchange.market_buy(req.as_ref()).await
     }
 
     pub async fn market_sell(
         &self,
         req: impl AsRef<OpenMarketOrderRequest>,
-    ) -> Result<Order<E::IdType>> {
+    ) -> Result<Order<E::OrderIdType>> {
         self.exchange.market_sell(req.as_ref()).await
     }
 
     pub async fn cancel_order(
         &self,
-        req: impl AsRef<CancelOrderRequest<E::IdType>>,
-    ) -> Result<OrderCanceled<E::IdType>> {
+        req: impl AsRef<CancelOrderRequest<E::OrderIdType>>,
+    ) -> Result<OrderCanceled<E::OrderIdType>> {
         self.exchange.cancel_order(req.as_ref()).await
     }
 
     pub async fn cancel_all_orders(
         &self,
         req: impl AsRef<CancelAllOrdersRequest>,
-    ) -> Result<Vec<OrderCanceled<E::IdType>>> {
+    ) -> Result<Vec<OrderCanceled<E::OrderIdType>>> {
         self.exchange.cancel_all_orders(req.as_ref()).await
     }
 
-    pub async fn get_all_open_orders(&self) -> Result<Vec<Order<E::IdType>>> {
+    pub async fn get_all_open_orders(&self) -> Result<Vec<Order<E::OrderIdType>>> {
         self.exchange.get_all_open_orders().await
     }
     pub async fn get_account_balances(&self) -> Result<Vec<Balance>> {
         self.exchange.get_account_balances().await
     }
+
+    pub async fn get_trade_history(
+        &self,
+        req: impl AsRef<TradeHistoryRequest<E::OrderIdType>>,
+    ) -> Result<Vec<Trade<E::TradeIdType, E::OrderIdType>>> {
+        self.exchange.get_trade_history(req.as_ref()).await
+    }
 }
 
 #[async_trait]
 pub trait Exchange {
-    type IdType;
+    type OrderIdType;
+    type TradeIdType;
     async fn order_book(&self, req: &OrderBookRequest) -> Result<OrderBookResponse>;
-    async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::IdType>>;
-    async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::IdType>>;
-    async fn market_buy(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::IdType>>;
-    async fn market_sell(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::IdType>>;
+    async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>>;
+    async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>>;
+    async fn market_buy(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::OrderIdType>>;
+    async fn market_sell(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::OrderIdType>>;
     async fn cancel_order(
         &self,
-        req: &CancelOrderRequest<Self::IdType>,
-    ) -> Result<OrderCanceled<Self::IdType>>;
+        req: &CancelOrderRequest<Self::OrderIdType>,
+    ) -> Result<OrderCanceled<Self::OrderIdType>>;
     async fn cancel_all_orders(
         &self,
         req: &CancelAllOrdersRequest,
-    ) -> Result<Vec<OrderCanceled<Self::IdType>>>;
-    async fn get_all_open_orders(&self) -> Result<Vec<Order<Self::IdType>>>;
+    ) -> Result<Vec<OrderCanceled<Self::OrderIdType>>>;
+    async fn get_all_open_orders(&self) -> Result<Vec<Order<Self::OrderIdType>>>;
     async fn get_account_balances(&self) -> Result<Vec<Balance>>;
+    async fn get_trade_history(
+        &self,
+        req: &TradeHistoryRequest<Self::OrderIdType>
+    ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>>;
 }

--- a/openlimits/src/exchange.rs
+++ b/openlimits/src/exchange.rs
@@ -2,7 +2,11 @@ use async_trait::async_trait;
 use derive_more::Constructor;
 use shared::Result;
 
-use crate::model::{Balance, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Trade, TradeHistoryRequest};
+use crate::model::{
+    Balance, CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest,
+    OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Trade,
+    TradeHistoryRequest,
+};
 
 #[derive(Constructor)]
 pub struct OpenLimits<E: Exchange> {
@@ -92,6 +96,6 @@ pub trait Exchange {
     async fn get_account_balances(&self) -> Result<Vec<Balance>>;
     async fn get_trade_history(
         &self,
-        req: &TradeHistoryRequest<Self::OrderIdType>
+        req: &TradeHistoryRequest<Self::OrderIdType>,
     ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>>;
 }

--- a/openlimits/src/model/mod.rs
+++ b/openlimits/src/model/mod.rs
@@ -47,6 +47,7 @@ pub struct Order<T> {
     pub client_order_id: Option<String>,
     pub created_at: DateTime<Utc>,
 }
+
 #[derive(Clone, Constructor, Debug)]
 pub struct CancelOrderRequest<T> {
     pub id: T,
@@ -61,6 +62,31 @@ pub struct CancelAllOrdersRequest {
 #[derive(Clone, Constructor, Debug)]
 pub struct OrderCanceled<T> {
     pub id: T,
+}
+
+#[derive(Clone, Constructor, Debug)]
+pub struct Trade<T, O> {
+    pub id: T,
+    pub order_id: O,
+    pub pair: String,
+    pub price: Decimal,
+    pub qty: Decimal,
+    pub fees: Decimal,
+    pub side: Side,
+    pub liquidity: Option<Liquidity>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum Liquidity {
+    Maker,
+    Taker,
+}
+
+#[derive(Default)]
+pub struct TradeHistoryRequest<T> {
+    pub pair: Option<String>,
+    pub order_id: Option<T>,
 }
 
 #[derive(Clone, Constructor, Debug)]

--- a/openlimits/tests/binance/account.rs
+++ b/openlimits/tests/binance/account.rs
@@ -3,9 +3,7 @@ use std::env;
 
 use openlimits::binance::Binance;
 use openlimits::exchange::Exchange;
-use openlimits::model::{
-    CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest,
-};
+use openlimits::model::{CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, TradeHistoryRequest};
 use rust_decimal::prelude::Decimal;
 
 #[tokio::test]
@@ -111,6 +109,18 @@ async fn get_all_open_orders() {
 async fn get_account_balances() {
     let exchange = init();
     let resp = exchange.get_account_balances().await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_trade_history() {
+    let exchange = init();
+    let req = TradeHistoryRequest {
+        pair: Some("BNBBTC".to_string()),
+        ..Default::default()
+    };
+
+    let resp = exchange.get_trade_history(&req).await.unwrap();
     println!("{:?}", resp);
 }
 

--- a/openlimits/tests/binance/account.rs
+++ b/openlimits/tests/binance/account.rs
@@ -3,7 +3,10 @@ use std::env;
 
 use openlimits::binance::Binance;
 use openlimits::exchange::Exchange;
-use openlimits::model::{CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, TradeHistoryRequest};
+use openlimits::model::{
+    CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest,
+    TradeHistoryRequest,
+};
 use rust_decimal::prelude::Decimal;
 
 #[tokio::test]

--- a/openlimits/tests/coinbase/account.rs
+++ b/openlimits/tests/coinbase/account.rs
@@ -3,7 +3,10 @@ use std::env;
 
 use openlimits::coinbase::Coinbase;
 use openlimits::exchange::Exchange;
-use openlimits::model::{CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, TradeHistoryRequest};
+use openlimits::model::{
+    CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest,
+    TradeHistoryRequest,
+};
 use rust_decimal::prelude::Decimal;
 
 #[tokio::test]

--- a/openlimits/tests/coinbase/account.rs
+++ b/openlimits/tests/coinbase/account.rs
@@ -3,9 +3,7 @@ use std::env;
 
 use openlimits::coinbase::Coinbase;
 use openlimits::exchange::Exchange;
-use openlimits::model::{
-    CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest,
-};
+use openlimits::model::{CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, TradeHistoryRequest};
 use rust_decimal::prelude::Decimal;
 
 #[tokio::test]
@@ -110,6 +108,18 @@ async fn get_all_open_orders() {
 async fn get_account_balances() {
     let exchange = init();
     let resp = exchange.get_account_balances().await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_trade_history() {
+    let exchange = init();
+    let req = TradeHistoryRequest {
+        pair: Some("ETH-BTC".to_string()),
+        ..Default::default()
+    };
+
+    let resp = exchange.get_trade_history(&req).await.unwrap();
     println!("{:?}", resp);
 }
 


### PR DESCRIPTION
Adding `get_trade_history` to the `Exchange` trait:

```Rust
async fn get_trade_history(
        &self,
        req: &TradeHistoryRequest<Self::OrderIdType>,
    ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>>;
```

`TradeHistoryRequest` is defined like this:

```Rust
#[derive(Default)]
pub struct TradeHistoryRequest<T> {
    pub pair: Option<String>,
    pub order_id: Option<T>,
}
```

Don't hesitate to give feedback!

Should close #31.