### PR TITLE
Add order history (close #33)

### DIFF
--- a/binance/src/client/account.rs
+++ b/binance/src/client/account.rs
@@ -74,6 +74,16 @@ impl Binance {
         Ok(orders)
     }
 
+    pub async fn get_all_orders(&self, symbol: &str) -> Result<Vec<Order>> {
+        let params = json! {{"symbol": symbol}};
+
+        let orders = self
+            .transport
+            .signed_get("/api/v3/allOrders", Some(&params))
+            .await?;
+        Ok(orders)
+    }
+
     // Check an order's status
     pub async fn order_status(&self, symbol: &str, order_id: u64) -> Result<Order> {
         let params = json! {{"symbol": symbol, "orderId": order_id}};

--- a/binance/tests/account.rs
+++ b/binance/tests/account.rs
@@ -32,6 +32,13 @@ async fn get_all_open_orders() {
 }
 
 #[tokio::test]
+async fn get_all_orders() {
+    let exchange = init();
+    let resp = exchange.get_all_orders("BNBBTC").await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
 async fn order_status() {
     let exchange = init();
     let transaction = exchange

--- a/coinbase/src/client/account.rs
+++ b/coinbase/src/client/account.rs
@@ -1,5 +1,3 @@
-use serde_json::json;
-
 use crate::model::{
     Account, CancelAllOrders, CancelOrder, Fill, Order, OrderRequest, OrderRequestMarketType,
     OrderRequestType, OrderSide,
@@ -9,6 +7,7 @@ use crate::Coinbase;
 use shared::Result;
 
 use rust_decimal::prelude::Decimal;
+use serde_json::json;
 
 impl Coinbase {
     pub async fn get_account(&self) -> Result<Vec<Account>> {
@@ -17,6 +16,18 @@ impl Coinbase {
 
     pub async fn get_all_open_orders(&self) -> Result<Vec<Order>> {
         self.transport.signed_get::<_, ()>("/orders", None).await
+    }
+
+    pub async fn get_all_orders<'a>(&self, product_id: Option<&str>) -> Result<Vec<Order>> {
+        let mut params = json! {{"status": "all"}};
+
+        if let Some(p) = product_id {
+            params["product_id"] = json!(p);
+        }
+
+        self.transport
+            .signed_get::<_, _>("/orders", Some(&params))
+            .await
     }
 
     pub async fn order_status(&self, order_id: String) -> Result<Order> {

--- a/coinbase/tests/account.rs
+++ b/coinbase/tests/account.rs
@@ -18,6 +18,20 @@ async fn get_all_open_orders() {
 }
 
 #[tokio::test]
+async fn get_all_orders() {
+    let exchange = init();
+    let resp = exchange.get_all_orders(None).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_all_orders_for_a_given_product() {
+    let exchange = init();
+    let resp = exchange.get_all_orders(Some("ETH-BTC")).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
 async fn order_status() {
     let exchange = init();
     let order = exchange

--- a/openlimits/src/binance/mod.rs
+++ b/openlimits/src/binance/mod.rs
@@ -93,6 +93,21 @@ impl Exchange for Binance {
             .map(|v| v.into_iter().map(Into::into).collect())
     }
 
+    async fn get_order_history(
+        &self,
+        req: &crate::model::GetOrderHistoryRequest,
+    ) -> Result<Vec<Order<Self::OrderIdType>>> {
+        if let Some(symbol) = req.symbol.as_ref() {
+            binance::Binance::get_all_orders(self, symbol.as_ref())
+                .await
+                .map(|v| v.into_iter().map(Into::into).collect())
+        } else {
+            Err(OpenLimitError::MissingParameter(
+                "symbol parameter is required.".to_string(),
+            ))
+        }
+    }
+
     async fn get_account_balances(&self) -> Result<Vec<Balance>> {
         binance::Binance::get_account(self)
             .await

--- a/openlimits/src/coinbase/mod.rs
+++ b/openlimits/src/coinbase/mod.rs
@@ -39,21 +39,25 @@ impl Exchange for Coinbase {
             .await
             .map(Into::into)
     }
+
     async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>> {
         coinbase::Coinbase::limit_buy(self, &req.symbol, req.size, req.price)
             .await
             .map(Into::into)
     }
+
     async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>> {
         coinbase::Coinbase::limit_sell(self, &req.symbol, req.size, req.price)
             .await
             .map(Into::into)
     }
+
     async fn market_buy(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::OrderIdType>> {
         coinbase::Coinbase::market_buy(self, &req.symbol, req.size)
             .await
             .map(Into::into)
     }
+
     async fn market_sell(&self, req: &OpenMarketOrderRequest) -> Result<Order<Self::OrderIdType>> {
         coinbase::Coinbase::market_sell(self, &req.symbol, req.size)
             .await
@@ -80,6 +84,15 @@ impl Exchange for Coinbase {
 
     async fn get_all_open_orders(&self) -> Result<Vec<Order<Self::OrderIdType>>> {
         coinbase::Coinbase::get_all_open_orders(self)
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())
+    }
+
+    async fn get_order_history(
+        &self,
+        req: &crate::model::GetOrderHistoryRequest,
+    ) -> Result<Vec<Order<Self::OrderIdType>>> {
+        coinbase::Coinbase::get_all_orders(self, req.symbol.as_deref())
             .await
             .map(|v| v.into_iter().map(Into::into).collect())
     }

--- a/openlimits/src/exchange.rs
+++ b/openlimits/src/exchange.rs
@@ -3,9 +3,9 @@ use derive_more::Constructor;
 use shared::Result;
 
 use crate::model::{
-    Balance, CancelAllOrdersRequest, CancelOrderRequest, GetPriceTickerRequest,
-    OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse,
-    OrderCanceled, Ticker, Trade, TradeHistoryRequest,
+    Balance, CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest,
+    GetPriceTickerRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest,
+    OrderBookResponse, OrderCanceled, Ticker, Trade, TradeHistoryRequest,
 };
 
 #[derive(Constructor)]
@@ -63,6 +63,14 @@ impl<E: Exchange> OpenLimits<E> {
     pub async fn get_all_open_orders(&self) -> Result<Vec<Order<E::OrderIdType>>> {
         self.exchange.get_all_open_orders().await
     }
+
+    pub async fn get_order_history(
+        &self,
+        req: impl AsRef<GetOrderHistoryRequest>,
+    ) -> Result<Vec<Order<E::OrderIdType>>> {
+        self.exchange.get_order_history(req.as_ref()).await
+    }
+
     pub async fn get_account_balances(&self) -> Result<Vec<Balance>> {
         self.exchange.get_account_balances().await
     }
@@ -93,6 +101,10 @@ pub trait Exchange {
         req: &CancelAllOrdersRequest,
     ) -> Result<Vec<OrderCanceled<Self::OrderIdType>>>;
     async fn get_all_open_orders(&self) -> Result<Vec<Order<Self::OrderIdType>>>;
+    async fn get_order_history(
+        &self,
+        req: &GetOrderHistoryRequest,
+    ) -> Result<Vec<Order<Self::OrderIdType>>>;
     async fn get_account_balances(&self) -> Result<Vec<Balance>>;
     async fn get_trade_history(
         &self,

--- a/openlimits/src/model/mod.rs
+++ b/openlimits/src/model/mod.rs
@@ -60,6 +60,11 @@ pub struct CancelAllOrdersRequest {
 }
 
 #[derive(Clone, Constructor, Debug)]
+pub struct GetOrderHistoryRequest {
+    pub symbol: Option<String>,
+}
+
+#[derive(Clone, Constructor, Debug)]
 pub struct OrderCanceled<T> {
     pub id: T,
 }

--- a/openlimits/tests/binance/account.rs
+++ b/openlimits/tests/binance/account.rs
@@ -4,8 +4,8 @@ use std::env;
 use openlimits::binance::Binance;
 use openlimits::exchange::Exchange;
 use openlimits::model::{
-    CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest,
-    TradeHistoryRequest,
+    CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest,
+    OpenMarketOrderRequest, TradeHistoryRequest,
 };
 use rust_decimal::prelude::Decimal;
 
@@ -91,6 +91,17 @@ async fn cancel_all_orders() {
     };
 
     let resp = exchange.cancel_all_orders(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_order_history() {
+    let exchange = init();
+    let req = GetOrderHistoryRequest {
+        symbol: Some(String::from("BNBBTC")),
+    };
+
+    let resp = exchange.get_order_history(&req).await.unwrap();
     println!("{:?}", resp);
 }
 

--- a/openlimits/tests/coinbase/account.rs
+++ b/openlimits/tests/coinbase/account.rs
@@ -4,8 +4,8 @@ use std::env;
 use openlimits::coinbase::Coinbase;
 use openlimits::exchange::Exchange;
 use openlimits::model::{
-    CancelAllOrdersRequest, CancelOrderRequest, OpenLimitOrderRequest, OpenMarketOrderRequest,
-    TradeHistoryRequest,
+    CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest,
+    OpenMarketOrderRequest, TradeHistoryRequest,
 };
 use rust_decimal::prelude::Decimal;
 
@@ -90,6 +90,17 @@ async fn cancel_all_orders() {
     };
 
     let resp = exchange.cancel_all_orders(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_order_history() {
+    let exchange = init();
+    let req = GetOrderHistoryRequest {
+        symbol: Some(String::from("ETH-BTC")),
+    };
+
+    let resp = exchange.get_order_history(&req).await.unwrap();
     println!("{:?}", resp);
 }
 


### PR DESCRIPTION
Added 

```Rust
    async fn get_order_history(
        &self,
        req: &GetOrderHistoryRequest,
    ) -> Result<Vec<Order<Self::OrderIdType>>>;
```

with

```Rust
#[derive(Clone, Constructor, Debug)]
pub struct GetOrderHistoryRequest {
    pub symbol: Option<String>,
}
```

`symbol` is optional for Coinbase but required for Binance.