### PR TITLE
Add historic rates (close #36)

### DIFF
--- a/coinbase/src/client/market.rs
+++ b/coinbase/src/client/market.rs
@@ -1,7 +1,7 @@
 use crate::Coinbase;
 
 use serde::Deserialize;
-use std::fmt::Debug;
+use std::{collections::HashMap, fmt::Debug};
 
 use shared::Result;
 
@@ -36,8 +36,10 @@ impl Coinbase {
         self.transport.get::<_, ()>(&endpoint, None).await
     }
 
-    pub async fn candles(&self, pair: &str) -> Result<Vec<Candle>> {
+    pub async fn candles(&self, pair: &str, granularity: u32) -> Result<Vec<Candle>> {
+        let params: HashMap<&str, u32> = [("granularity", granularity)].iter().cloned().collect();
+
         let endpoint = format!("/products/{}/candles", pair);
-        self.transport.get::<_, ()>(&endpoint, None).await
+        self.transport.get(&endpoint, Some(&params)).await
     }
 }

--- a/coinbase/tests/market.rs
+++ b/coinbase/tests/market.rs
@@ -39,6 +39,6 @@ async fn ticker() {
 #[tokio::test]
 async fn candles() {
     let exchange = Coinbase::new(true);
-    let res = exchange.candles("BTC-USD").await.unwrap();
+    let res = exchange.candles("BTC-USD", 86400).await.unwrap();
     println!("{:?}", res);
 }

--- a/openlimits/src/exchange.rs
+++ b/openlimits/src/exchange.rs
@@ -81,6 +81,13 @@ impl<E: Exchange> OpenLimits<E> {
     ) -> Result<Vec<Trade<E::TradeIdType, E::OrderIdType>>> {
         self.exchange.get_trade_history(req.as_ref()).await
     }
+
+    pub async fn get_historic_rates(
+        &self,
+        req: impl AsRef<GetHistoricRatesRequest>,
+    ) -> Result<Vec<Candle>> {
+        self.exchange.get_historic_rates(req.as_ref()).await
+    }
 }
 
 #[async_trait]

--- a/openlimits/src/exchange.rs
+++ b/openlimits/src/exchange.rs
@@ -3,9 +3,9 @@ use derive_more::Constructor;
 use shared::Result;
 
 use crate::model::{
-    Balance, CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest,
-    GetPriceTickerRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest,
-    OrderBookResponse, OrderCanceled, Ticker, Trade, TradeHistoryRequest,
+    Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle, GetHistoricRatesRequest,
+    GetOrderHistoryRequest, GetPriceTickerRequest, OpenLimitOrderRequest, OpenMarketOrderRequest,
+    Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Ticker, Trade, TradeHistoryRequest,
 };
 
 #[derive(Constructor)]
@@ -111,4 +111,5 @@ pub trait Exchange {
         req: &TradeHistoryRequest<Self::OrderIdType>,
     ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>>;
     async fn get_price_ticker(&self, req: &GetPriceTickerRequest) -> Result<Ticker>;
+    async fn get_historic_rates(&self, req: &GetHistoricRatesRequest) -> Result<Vec<Candle>>;
 }

--- a/openlimits/src/model/mod.rs
+++ b/openlimits/src/model/mod.rs
@@ -105,13 +105,48 @@ pub struct Ticker {
     pub price: Decimal,
 }
 
+#[derive(Clone, Constructor, Debug)]
+pub struct Candle {
+    pub time: u64,
+    pub low: Decimal,
+    pub high: Decimal,
+    pub open: Decimal,
+    pub close: Decimal,
+    pub volume: Decimal,
+}
+
 #[derive(Clone, Constructor, Debug, Default)]
 pub struct GetPriceTickerRequest {
     pub symbol: String,
+}
+
+#[derive(Clone, Constructor, Debug)]
+pub struct GetHistoricRatesRequest {
+    pub symbol: String,
+    pub interval: Interval,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Side {
     Buy,
     Sell,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+pub enum Interval {
+    OneMinute,
+    ThreeMinutes,
+    FiveMinutes,
+    FiftyMinutes,
+    ThirtyMinutes,
+    OneHour,
+    TwoHours,
+    FourHours,
+    SixHours,
+    EightHours,
+    TwelveHours,
+    OneDay,
+    ThreeDay,
+    OneWeek,
+    OneMonth,
 }

--- a/openlimits/tests/binance/market.rs
+++ b/openlimits/tests/binance/market.rs
@@ -1,6 +1,8 @@
 use openlimits::binance::Binance;
 use openlimits::exchange::Exchange;
-use openlimits::model::{GetPriceTickerRequest, OrderBookRequest};
+use openlimits::model::{
+    GetHistoricRatesRequest, GetPriceTickerRequest, Interval, OrderBookRequest,
+};
 
 #[tokio::test]
 async fn order_book() {
@@ -19,5 +21,16 @@ async fn get_price_ticker() {
         symbol: "BNBBTC".to_string(),
     };
     let resp = exchange.get_price_ticker(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_historic_rates() {
+    let exchange = Binance::new(true);
+    let req = GetHistoricRatesRequest {
+        symbol: "BNBBTC".to_string(),
+        interval: Interval::OneHour,
+    };
+    let resp = exchange.get_historic_rates(&req).await.unwrap();
     println!("{:?}", resp);
 }

--- a/openlimits/tests/coinbase/market.rs
+++ b/openlimits/tests/coinbase/market.rs
@@ -1,6 +1,8 @@
 use openlimits::coinbase::Coinbase;
 use openlimits::exchange::Exchange;
-use openlimits::model::{GetPriceTickerRequest, OrderBookRequest};
+use openlimits::model::{
+    GetHistoricRatesRequest, GetPriceTickerRequest, Interval, OrderBookRequest,
+};
 
 #[tokio::test]
 async fn order_book() {
@@ -20,4 +22,26 @@ async fn get_price_ticker() {
     };
     let resp = exchange.get_price_ticker(&req).await.unwrap();
     println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_historic_rates() {
+    let exchange = Coinbase::new(true);
+    let req = GetHistoricRatesRequest {
+        symbol: "ETH-BTC".to_string(),
+        interval: Interval::OneHour,
+    };
+    let resp = exchange.get_historic_rates(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_historic_rates_invalid_interval() {
+    let exchange = Coinbase::new(true);
+    let req = GetHistoricRatesRequest {
+        symbol: "ETH-BTC".to_string(),
+        interval: Interval::TwoHours,
+    };
+    let resp = exchange.get_historic_rates(&req).await;
+    assert!(resp.is_err());
 }


### PR DESCRIPTION
Method declaration:

```Rust
async fn get_historic_rates(&self, req: &GetHistoricRatesRequest) -> Result<Vec<Candle>>;
```

Added an enum to specify intervals:

```Rust
#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
pub enum Interval {
    OneMinute,
    ThreeMinutes,
    FiveMinutes,
    FiftyMinutes,
    ThirtyMinutes,
    OneHour,
    TwoHours,
    FourHours,
    SixHours,
    EightHours,
    TwelveHours,
    OneDay,
    ThreeDay,
    OneWeek,
    OneMonth,
}
```

Coinbase handle only `1m`, `5m`, `15m`, `1h`, `6h` and `1d`, so an error is returned when specifing another interval.