### PR TITLE
Add historic rates (close #36)

### DIFF
--- a/coinbase/src/client/market.rs
+++ b/coinbase/src/client/market.rs
@@ -39,9 +39,9 @@ impl Coinbase {
     pub async fn candles(
         &self,
         pair: &str,
-        parms: Option<&CandleRequestParams>,
+        params: Option<&CandleRequestParams>,
     ) -> Result<Vec<Candle>> {
         let endpoint = format!("/products/{}/candles", pair);
-        self.transport.get(&endpoint, parms).await
+        self.transport.get(&endpoint, params).await
     }
 }

--- a/coinbase/src/model/mod.rs
+++ b/coinbase/src/model/mod.rs
@@ -198,7 +198,7 @@ pub struct OrderRequest {
 pub struct CandleRequestParams {
     #[serde(flatten)]
     pub daterange: Option<DateRange>,
-    pub granularity: Option<i64>,
+    pub granularity: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/coinbase/src/model/mod.rs
+++ b/coinbase/src/model/mod.rs
@@ -300,7 +300,7 @@ pub struct Paginator {
     pub after: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DateRange {
     #[serde(with = "opt_naive_datetime_from_string")]

--- a/openlimits/src/exchange.rs
+++ b/openlimits/src/exchange.rs
@@ -81,6 +81,13 @@ impl<E: Exchange> OpenLimits<E> {
     ) -> Result<Vec<Trade<E::TradeIdType, E::OrderIdType>>> {
         self.exchange.get_trade_history(req.as_ref()).await
     }
+
+    pub async fn get_historic_rates(
+        &self,
+        req: impl AsRef<GetHistoricRatesRequest>,
+    ) -> Result<Vec<Candle>> {
+        self.exchange.get_historic_rates(req.as_ref()).await
+    }
 }
 
 #[async_trait]

--- a/openlimits/src/exchange.rs
+++ b/openlimits/src/exchange.rs
@@ -3,9 +3,9 @@ use derive_more::Constructor;
 use shared::Result;
 
 use crate::model::{
-    Balance, CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest,
-    GetPriceTickerRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest,
-    OrderBookResponse, OrderCanceled, Ticker, Trade, TradeHistoryRequest,
+    Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle, GetHistoricRatesRequest,
+    GetOrderHistoryRequest, GetPriceTickerRequest, OpenLimitOrderRequest, OpenMarketOrderRequest,
+    Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Ticker, Trade, TradeHistoryRequest,
 };
 
 #[derive(Constructor)]
@@ -111,4 +111,5 @@ pub trait Exchange {
         req: &TradeHistoryRequest<Self::OrderIdType>,
     ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>>;
     async fn get_price_ticker(&self, req: &GetPriceTickerRequest) -> Result<Ticker>;
+    async fn get_historic_rates(&self, req: &GetHistoricRatesRequest) -> Result<Vec<Candle>>;
 }

--- a/openlimits/src/model/mod.rs
+++ b/openlimits/src/model/mod.rs
@@ -105,13 +105,48 @@ pub struct Ticker {
     pub price: Decimal,
 }
 
+#[derive(Clone, Constructor, Debug)]
+pub struct Candle {
+    pub time: u64,
+    pub low: Decimal,
+    pub high: Decimal,
+    pub open: Decimal,
+    pub close: Decimal,
+    pub volume: Decimal,
+}
+
 #[derive(Clone, Constructor, Debug, Default)]
 pub struct GetPriceTickerRequest {
     pub symbol: String,
+}
+
+#[derive(Clone, Constructor, Debug)]
+pub struct GetHistoricRatesRequest {
+    pub symbol: String,
+    pub interval: Interval,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Side {
     Buy,
     Sell,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+pub enum Interval {
+    OneMinute,
+    ThreeMinutes,
+    FiveMinutes,
+    FiftyMinutes,
+    ThirtyMinutes,
+    OneHour,
+    TwoHours,
+    FourHours,
+    SixHours,
+    EightHours,
+    TwelveHours,
+    OneDay,
+    ThreeDay,
+    OneWeek,
+    OneMonth,
 }

--- a/openlimits/src/model/mod.rs
+++ b/openlimits/src/model/mod.rs
@@ -1,3 +1,4 @@
+use coinbase::model::DateRange;
 use derive_more::Constructor;
 use rust_decimal::prelude::Decimal;
 use serde::{Deserialize, Serialize};
@@ -123,6 +124,7 @@ pub struct GetPriceTickerRequest {
 #[derive(Clone, Constructor, Debug)]
 pub struct GetHistoricRatesRequest {
     pub symbol: String,
+    pub daterange: Option<DateRange>,
     pub interval: Interval,
 }
 

--- a/openlimits/tests/binance/market.rs
+++ b/openlimits/tests/binance/market.rs
@@ -1,6 +1,8 @@
 use openlimits::binance::Binance;
 use openlimits::exchange::Exchange;
-use openlimits::model::{GetPriceTickerRequest, OrderBookRequest};
+use openlimits::model::{
+    GetHistoricRatesRequest, GetPriceTickerRequest, Interval, OrderBookRequest,
+};
 
 #[tokio::test]
 async fn order_book() {
@@ -19,5 +21,16 @@ async fn get_price_ticker() {
         symbol: "BNBBTC".to_string(),
     };
     let resp = exchange.get_price_ticker(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_historic_rates() {
+    let exchange = Binance::new(true);
+    let req = GetHistoricRatesRequest {
+        symbol: "BNBBTC".to_string(),
+        interval: Interval::OneHour,
+    };
+    let resp = exchange.get_historic_rates(&req).await.unwrap();
     println!("{:?}", resp);
 }

--- a/openlimits/tests/binance/market.rs
+++ b/openlimits/tests/binance/market.rs
@@ -30,6 +30,7 @@ async fn get_historic_rates() {
     let req = GetHistoricRatesRequest {
         symbol: "BNBBTC".to_string(),
         interval: Interval::OneHour,
+        daterange: None,
     };
     let resp = exchange.get_historic_rates(&req).await.unwrap();
     println!("{:?}", resp);

--- a/openlimits/tests/coinbase/market.rs
+++ b/openlimits/tests/coinbase/market.rs
@@ -30,6 +30,7 @@ async fn get_historic_rates() {
     let req = GetHistoricRatesRequest {
         symbol: "ETH-BTC".to_string(),
         interval: Interval::OneHour,
+        daterange: None,
     };
     let resp = exchange.get_historic_rates(&req).await.unwrap();
     println!("{:?}", resp);
@@ -41,6 +42,7 @@ async fn get_historic_rates_invalid_interval() {
     let req = GetHistoricRatesRequest {
         symbol: "ETH-BTC".to_string(),
         interval: Interval::TwoHours,
+        daterange: None,
     };
     let resp = exchange.get_historic_rates(&req).await;
     assert!(resp.is_err());

--- a/openlimits/tests/coinbase/market.rs
+++ b/openlimits/tests/coinbase/market.rs
@@ -1,6 +1,8 @@
 use openlimits::coinbase::Coinbase;
 use openlimits::exchange::Exchange;
-use openlimits::model::{GetPriceTickerRequest, OrderBookRequest};
+use openlimits::model::{
+    GetHistoricRatesRequest, GetPriceTickerRequest, Interval, OrderBookRequest,
+};
 
 #[tokio::test]
 async fn order_book() {
@@ -20,4 +22,26 @@ async fn get_price_ticker() {
     };
     let resp = exchange.get_price_ticker(&req).await.unwrap();
     println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_historic_rates() {
+    let exchange = Coinbase::new(true);
+    let req = GetHistoricRatesRequest {
+        symbol: "ETH-BTC".to_string(),
+        interval: Interval::OneHour,
+    };
+    let resp = exchange.get_historic_rates(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_historic_rates_invalid_interval() {
+    let exchange = Coinbase::new(true);
+    let req = GetHistoricRatesRequest {
+        symbol: "ETH-BTC".to_string(),
+        interval: Interval::TwoHours,
+    };
+    let resp = exchange.get_historic_rates(&req).await;
+    assert!(resp.is_err());
 }


### PR DESCRIPTION
Method declaration:

```Rust
async fn get_historic_rates(&self, req: &GetHistoricRatesRequest) -> Result<Vec<Candle>>;
```

Added an enum to specify intervals:

```Rust
#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
pub enum Interval {
    OneMinute,
    ThreeMinutes,
    FiveMinutes,
    FiftyMinutes,
    ThirtyMinutes,
    OneHour,
    TwoHours,
    FourHours,
    SixHours,
    EightHours,
    TwelveHours,
    OneDay,
    ThreeDay,
    OneWeek,
    OneMonth,
}
```

Coinbase handle only `1m`, `5m`, `15m`, `1h`, `6h` and `1d`, so an error is returned when specifing another interval.