### PR TITLE
impl Into<chrono::Duration> for model::Interval

### DIFF
--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -321,7 +321,7 @@ impl From<Interval> for &str {
             Interval::OneMinute => "1m",
             Interval::ThreeMinutes => "3m",
             Interval::FiveMinutes => "5m",
-            Interval::FiftyMinutes => "15m",
+            Interval::FifteenMinutes => "15m",
             Interval::ThirtyMinutes => "30m",
             Interval::OneHour => "1h",
             Interval::TwoHours => "2h",
@@ -330,7 +330,7 @@ impl From<Interval> for &str {
             Interval::EightHours => "8h",
             Interval::TwelveHours => "12h",
             Interval::OneDay => "1d",
-            Interval::ThreeDay => "3d",
+            Interval::ThreeDays => "3d",
             Interval::OneWeek => "1w",
             Interval::OneMonth => "1M",
         }

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -292,7 +292,7 @@ impl TryFrom<Interval> for u32 {
         match value {
             Interval::OneMinute => Ok(60),
             Interval::FiveMinutes => Ok(300),
-            Interval::FiftyMinutes => Ok(900),
+            Interval::FifteenMinutes => Ok(900),
             Interval::OneHour => Ok(3600),
             Interval::SixHours => Ok(21600),
             Interval::OneDay => Ok(86400),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -153,7 +153,7 @@ pub enum Interval {
     OneMinute,
     ThreeMinutes,
     FiveMinutes,
-    FiftyMinutes,
+    FifteenMinutes,
     ThirtyMinutes,
     OneHour,
     TwoHours,
@@ -162,7 +162,7 @@ pub enum Interval {
     EightHours,
     TwelveHours,
     OneDay,
-    ThreeDay,
+    ThreeDays,
     OneWeek,
     OneMonth,
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,6 +1,7 @@
 use derive_more::Constructor;
 use rust_decimal::prelude::Decimal;
 use serde::{Deserialize, Serialize};
+use chrono::Duration;
 
 #[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default)]
 pub struct OrderBookRequest {
@@ -165,6 +166,32 @@ pub enum Interval {
     ThreeDays,
     OneWeek,
     OneMonth,
+}
+impl Into<Duration> for Interval {
+    fn into(self) -> Duration {
+        match self {
+            Self::OneMinute => Duration::minutes(1),
+            Self::ThreeMinutes => Duration::minutes(3),
+            Self::FiveMinutes => Duration::minutes(5),
+            Self::FifteenMinutes => Duration::minutes(15),
+            Self::ThirtyMinutes => Duration::minutes(30),
+            Self::OneHour => Duration::hours(1),
+            Self::TwoHours => Duration::hours(2),
+            Self::FourHours => Duration::hours(4),
+            Self::SixHours => Duration::hours(6),
+            Self::EightHours => Duration::hours(8),
+            Self::TwelveHours => Duration::hours(12),
+            Self::OneDay => Duration::days(1),
+            Self::ThreeDays => Duration::days(3),
+            Self::OneWeek => Duration::weeks(1),
+            Self::OneMonth => Duration::days(30),
+        }
+    }
+}
+impl Interval {
+    pub fn to_duration(self) -> Duration {
+        self.into()
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,32 +3,32 @@ use rust_decimal::prelude::Decimal;
 use serde::{Deserialize, Serialize};
 use chrono::Duration;
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
 pub struct OrderBookRequest {
     pub market_pair: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
 pub struct OrderBookResponse {
     pub last_update_id: Option<u64>,
     pub bids: Vec<AskBid>,
     pub asks: Vec<AskBid>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
 pub struct AskBid {
     pub price: Decimal,
     pub qty: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
 pub struct OpenLimitOrderRequest {
     pub market_pair: String,
     pub size: Decimal,
     pub price: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
 pub struct OpenMarketOrderRequest {
     pub market_pair: String,
     pub size: Decimal,
@@ -67,7 +67,7 @@ pub struct CancelOrderRequest<T> {
     pub market_pair: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]
 pub struct CancelAllOrdersRequest {
     pub market_pair: Option<String>,
 }
@@ -96,7 +96,7 @@ pub struct Trade<T, O> {
     pub created_at: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Liquidity {
     Maker,
     Taker,
@@ -109,19 +109,19 @@ pub struct TradeHistoryRequest<T, U> {
     pub paginator: Option<Paginator<U>>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]
 pub struct Balance {
     pub asset: String,
     pub total: Decimal,
     pub free: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]
 pub struct Ticker {
     pub price: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]
 pub struct Candle {
     pub time: u64,
     pub low: Decimal,
@@ -131,7 +131,7 @@ pub struct Candle {
     pub volume: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
 pub struct GetPriceTickerRequest {
     pub market_pair: String,
 }
@@ -143,13 +143,13 @@ pub struct GetHistoricRatesRequest<T> {
     pub interval: Interval,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Side {
     Buy,
     Sell,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 pub enum Interval {
     OneMinute,
     ThreeMinutes,
@@ -194,7 +194,7 @@ impl Interval {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OrderStatus {
     New,


### PR DESCRIPTION
This fixes two naming errors in the `model::Interval` enum:
`Interval::FiftyMinutes -> Interval::FifteenMinutes`
`Interval::ThreeDay -> Interval::ThreeDays`

And this enables:
```rust
model::Interval::FourHours.to_duration().num_milliseconds()
```