### PR TITLE
Disable incompatible code on wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3.5"
 hex = "0.4.2"
 hmac = "0.8.1"
 log = "0.4.8"
-reqwest = { version = "0.10", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json", "blocking"] }
 rust_decimal = "1.7.0"
 sugar = "0.2.0"
 serde = { version = "1.0.114", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,15 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.6.1"
 thiserror = "1.0.20"
-tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = { version = "0.13.0", features = ["tls"] }
-tungstenite = "0.12.0"
+
 sha2 = "0.9.1"
 url = "2.1.1"
 derive_more = "0.99"
+pyo3 = { version = "0.12.3", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = { version = "0.13.0", features = ["tls"] }
+tungstenite = "0.12.0"
 nash-protocol = { version = "=0.1.20", default-features = false, features = ["rustcrypto"] }
 nash-native-client = { version = "=0.1.13", default-features = false, features = ["rustcrypto"] }
-pyo3 = { version = "0.12.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 serde_urlencoded = "0.6.1"
 thiserror = "1.0.20"
-tokio = { version = "0.2", features = ["full"] }
-tokio-tungstenite = { version = "0.10.1", features = ["tls"] }
-tungstenite = "0.11.0"
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = { version = "0.13.0", features = ["tls"] }
+tungstenite = "0.12.0"
 sha2 = "0.9.1"
 url = "2.1.1"
 derive_more = "0.99"

--- a/src/binance/transport.rs
+++ b/src/binance/transport.rs
@@ -157,6 +157,7 @@ impl Transport {
         Ok(self.response_handler(request).await?)
     }
 
+    #[allow(unused)]
     pub async fn signed_put<O, Q>(&self, endpoint: &str, data: Option<&Q>) -> Result<O>
     where
         O: DeserializeOwned,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,10 +50,12 @@ pub enum OpenLimitError {
     #[error(transparent)]
     CoinbaseError(#[from] CoinbaseContentError),
     #[error(transparent)]
+    #[cfg(not(target_arch="wasm32"))]
     NashProtocolError(#[from] nash_protocol::errors::ProtocolError),
     #[error(transparent)]
     MissingImplementation(#[from] MissingImplementationContent),
     #[error("")]
+    #[cfg(not(target_arch="wasm32"))]
     AssetNotFound(),
     #[error("")]
     NoApiKeySet(),
@@ -88,6 +90,7 @@ pub enum OpenLimitError {
     #[error(transparent)]
     UrlParserError(#[from] url::ParseError),
     #[error(transparent)]
+    #[cfg(not(target_arch="wasm32"))]
     Tungstenite(#[from] tokio_tungstenite::tungstenite::Error),
     #[error(transparent)]
     TimestampError(#[from] std::time::SystemTimeError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,19 @@
 #![deny(unstable_features)]
 #![warn(unused_import_braces)]
 
+#[cfg(not(target_arch="wasm32"))]
 pub mod binance;
+#[cfg(not(target_arch="wasm32"))]
 pub mod coinbase;
 pub mod errors;
 pub mod exchange;
 pub mod exchange_info;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod exchange_ws;
 pub mod model;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod nash;
 pub mod shared;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod any_exchange;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@
 #![deny(unstable_features)]
 #![warn(unused_import_braces)]
 
-#[cfg(not(target_arch="wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod binance;
-#[cfg(not(target_arch="wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod coinbase;
 pub mod errors;
 pub mod exchange;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -12,12 +12,12 @@ pub mod python;
 
 pub mod websocket;
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq, Eq, Hash)]
 pub struct OrderBookRequest {
     pub market_pair: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq, Eq, Hash)]
 pub struct OrderBookResponse {
     pub update_id: Option<u64>,
     pub last_update_id: Option<u64>,
@@ -25,13 +25,13 @@ pub struct OrderBookResponse {
     pub asks: Vec<AskBid>,
 }
 
-#[derive(Serialize, Deserialize, Copy, Clone, Constructor, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Constructor, Debug, Default, PartialEq, Eq, Hash)]
 pub struct AskBid {
     pub price: Decimal,
     pub qty: Decimal,
 }
 
-#[derive(Clone, Debug, PartialEq, Copy)]
+#[derive(Clone, Debug, PartialEq, Copy, Eq, Hash)]
 pub enum TimeInForce {
     GoodTillCancelled,
     ImmediateOrCancelled,
@@ -99,7 +99,7 @@ impl Default for TimeInForce {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq, Eq, Hash)]
 pub struct OpenLimitOrderRequest {
     pub market_pair: String,
     pub size: Decimal,
@@ -108,7 +108,7 @@ pub struct OpenLimitOrderRequest {
     pub post_only: bool,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq, Eq, Hash)]
 pub struct OpenMarketOrderRequest {
     pub market_pair: String,
     pub size: Decimal,
@@ -149,7 +149,7 @@ pub struct CancelOrderRequest {
     pub market_pair: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq, Eq, Hash)]
 pub struct CancelAllOrdersRequest {
     pub market_pair: Option<String>,
 }
@@ -179,7 +179,7 @@ pub struct Trade {
     pub created_at: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Liquidity {
     Maker,
@@ -193,20 +193,20 @@ pub struct TradeHistoryRequest {
     pub paginator: Option<Paginator>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq, Eq, Hash)]
 pub struct Balance {
     pub asset: String,
     pub total: Decimal,
     pub free: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq, Eq, Hash)]
 pub struct Ticker {
     pub price: Option<Decimal>,
     pub price_24h: Option<Decimal>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq, Eq, Hash)]
 pub struct Candle {
     pub time: u64,
     pub low: Decimal,
@@ -216,7 +216,7 @@ pub struct Candle {
     pub volume: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq, Eq, Hash)]
 pub struct GetPriceTickerRequest {
     pub market_pair: String,
 }
@@ -234,14 +234,14 @@ pub struct GetHistoricTradesRequest {
     pub paginator: Option<Paginator>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Side {
     Buy,
     Sell,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Interval {
     #[serde(rename = "1m")]
     OneMinute,
@@ -301,7 +301,7 @@ impl Interval {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OrderStatus {
     New,

--- a/tests/apis/binance/websocket.rs
+++ b/tests/apis/binance/websocket.rs
@@ -21,63 +21,63 @@ async fn test_subscription_callback(websocket: BinanceWebsocket, sub: BinanceSub
     rx.recv().expect("Couldn't receive sync message.");
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn aggregate_trade() {
     let websocket = init().await;
     let sub = BinanceSubscription::AggregateTrade("bnbbtc".to_string());
     test_subscription_callback(websocket, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn candlestick() {
     let websocket = init().await;
     let sub = BinanceSubscription::Candlestick("bnbbtc".to_string(), "1m".to_string());
     test_subscription_callback(websocket, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn depth() {
     let websocket = init().await;
     let sub = BinanceSubscription::Depth("bnbbtc".to_string(), Some(1));
     test_subscription_callback(websocket, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mini_ticker() {
     let websocket = init().await;
     let sub = BinanceSubscription::MiniTicker("bnbbtc".to_string());
     test_subscription_callback(websocket, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mini_ticker_all() {
     let websocket = init().await;
     let sub = BinanceSubscription::MiniTickerAll;
     test_subscription_callback(websocket, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn order_book() {
     let websocket = init().await;
     let sub = BinanceSubscription::OrderBook("bnbbtc".to_string(), 10);
     test_subscription_callback(websocket, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn ticker() {
     let websocket = init().await;
     let sub = BinanceSubscription::Ticker("bnbbtc".to_string());
     test_subscription_callback(websocket, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn ticker_all() {
     let websocket = init().await;
     let sub = BinanceSubscription::TickerAll;
     test_subscription_callback(websocket, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trade() {
     let websocket = init().await;
     let sub = BinanceSubscription::Trade("bnbbtc".to_string());

--- a/tests/apis/coinbase/websocket.rs
+++ b/tests/apis/coinbase/websocket.rs
@@ -42,7 +42,7 @@ async fn test_subscription_callback(
         .expect("Couldn't receive sync message.");
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn order_book() {
     let websocket = init().await;
     let sub = CoinbaseSubscription::Level2("BTC-USD".to_string());

--- a/tests/binance/ws_callbacks.rs
+++ b/tests/binance/ws_callbacks.rs
@@ -20,14 +20,14 @@ async fn test_subscription_callback(websocket: OpenLimitsWs<BinanceWebsocket>, s
     rx.recv().expect("Couldn't receive sync message.");
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn orderbook() {
     let ws = init().await;
     let sub = Subscription::OrderBookUpdates("bnbbtc".to_string());
     test_subscription_callback(ws, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trades() {
     let ws = init().await;
     let sub = Subscription::Trades("btcusdt".to_string());

--- a/tests/binance/ws_streams.rs
+++ b/tests/binance/ws_streams.rs
@@ -5,7 +5,7 @@ use openlimits::{
     model::websocket::Subscription,
 };
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn orderbook() {
     let ws = init().await;
     let s = ws
@@ -17,7 +17,7 @@ async fn orderbook() {
     print!("{:?}", ob);
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trades() {
     let ws = init().await;
     let s = ws

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,7 +1,10 @@
 extern crate openlimits;
 
 mod any_exchange;
+#[cfg(not(target_arch="wasm32"))]
 mod apis;
+#[cfg(not(target_arch="wasm32"))]
 mod binance;
+#[cfg(not(target_arch="wasm32"))]
 mod coinbase;
 mod nash;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,8 +3,8 @@ extern crate openlimits;
 mod any_exchange;
 #[cfg(not(target_arch="wasm32"))]
 mod apis;
-#[cfg(not(target_arch="wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 mod binance;
-#[cfg(not(target_arch="wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 mod coinbase;
 mod nash;

--- a/tests/nash/websocket.rs
+++ b/tests/nash/websocket.rs
@@ -18,14 +18,14 @@ async fn test_subscription_callback(websocket: OpenLimitsWs<NashWebsocket>, sub:
     rx.recv().expect("Couldn't receive sync message.");
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn orderbook() {
     let client = init().await;
     let sub = Subscription::OrderBookUpdates("btc_usdc".to_string());
     test_subscription_callback(client, sub).await;
 }
 
-#[tokio::test(core_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trades() {
     let client = init().await;
     let sub = Subscription::Trades("btc_usdc".to_string());


### PR DESCRIPTION
This makes the crate as least be compiled for wasm32 and allows you to
use the types in the model module for web APIs and stuff