### PR TITLE
Add Nash market retrieval and expose market list across all exchange clients

### DIFF
--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -8,7 +8,7 @@ use client::websocket::BinanceWebsocket;
 use crate::{
     errors::OpenLimitError,
     exchange::Exchange,
-    exchange_info::ExchangeInfo,
+    exchange_info::{ExchangeInfo, MarketPairHandle},
     exchange_ws::ExchangeWs,
     model::{
         websocket::{OpenLimitsWebsocketMessage, Subscription},
@@ -64,7 +64,7 @@ impl Exchange for Binance {
             .map(Into::into)
     }
 
-    async fn refresh_market_info(&self) -> Result<()> {
+    async fn refresh_market_info(&self) -> Result<Vec<MarketPairHandle>> {
         self.exchange_info.refresh(self).await
     }
 

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -5,7 +5,7 @@ mod transport;
 use crate::{
     errors::OpenLimitError,
     exchange::Exchange,
-    exchange_info::ExchangeInfo,
+    exchange_info::{ExchangeInfo, MarketPairHandle},
     model::{
         AskBid, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
         GetHistoricRatesRequest, GetOrderHistoryRequest, GetOrderRequest, GetPriceTickerRequest,
@@ -65,7 +65,7 @@ impl Exchange for Coinbase {
             .map(Into::into)
     }
 
-    async fn refresh_market_info(&self) -> Result<()> {
+    async fn refresh_market_info(&self) -> Result<Vec<MarketPairHandle>> {
         self.exchange_info.refresh(self).await
     }
 

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -2,13 +2,13 @@ use async_trait::async_trait;
 use derive_more::Constructor;
 
 use crate::{
+    exchange_info::MarketPairHandle,
     model::{
         Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle, GetHistoricRatesRequest,
         GetOrderHistoryRequest, GetOrderRequest, GetPriceTickerRequest, OpenLimitOrderRequest,
         OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled,
         Paginator, Ticker, Trade, TradeHistoryRequest,
     },
-    exchange_info::MarketPairHandle,
     shared::Result,
 };
 

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -8,6 +8,7 @@ use crate::{
         OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled,
         Paginator, Ticker, Trade, TradeHistoryRequest,
     },
+    exchange_info::MarketPairHandle,
     shared::Result,
 };
 
@@ -17,7 +18,7 @@ pub struct OpenLimits<E: Exchange> {
 }
 
 impl<E: Exchange> OpenLimits<E> {
-    pub async fn refresh_market_info(&self) -> Result<()> {
+    pub async fn refresh_market_info(&self) -> Result<Vec<MarketPairHandle>> {
         self.exchange.refresh_market_info().await
     }
 
@@ -104,7 +105,7 @@ pub trait Exchange {
     type OrderIdType;
     type TradeIdType;
     type PaginationType;
-    async fn refresh_market_info(&self) -> Result<()>;
+    async fn refresh_market_info(&self) -> Result<Vec<MarketPairHandle>>;
     async fn order_book(&self, req: &OrderBookRequest) -> Result<OrderBookResponse>;
     async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>>;
     async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order<Self::OrderIdType>>;

--- a/src/exchange_info.rs
+++ b/src/exchange_info.rs
@@ -74,10 +74,16 @@ impl ExchangeInfo {
 
     pub fn list_pairs(&self) -> Vec<MarketPairHandle> {
         let market_map = self.pairs.read().unwrap();
-        market_map.iter().map(|(_symbol,market)| MarketPairHandle::new(market.clone())).collect()
+        market_map
+            .iter()
+            .map(|(_symbol, market)| MarketPairHandle::new(market.clone()))
+            .collect()
     }
 
-    pub async fn refresh(&self, retrieval: &dyn ExchangeInfoRetrieval) -> Result<Vec<MarketPairHandle>> {
+    pub async fn refresh(
+        &self,
+        retrieval: &dyn ExchangeInfoRetrieval,
+    ) -> Result<Vec<MarketPairHandle>> {
         let pairs = retrieval.retrieve_pairs().await?;
 
         if let Ok(mut writable_pairs) = self.pairs.write() {

--- a/src/exchange_info.rs
+++ b/src/exchange_info.rs
@@ -72,7 +72,12 @@ impl ExchangeInfo {
         })
     }
 
-    pub async fn refresh(&self, retrieval: &dyn ExchangeInfoRetrieval) -> Result<()> {
+    pub fn list_pairs(&self) -> Vec<MarketPairHandle> {
+        let market_map = self.pairs.read().unwrap();
+        market_map.iter().map(|(_symbol,market)| MarketPairHandle::new(market.clone())).collect()
+    }
+
+    pub async fn refresh(&self, retrieval: &dyn ExchangeInfoRetrieval) -> Result<Vec<MarketPairHandle>> {
         let pairs = retrieval.retrieve_pairs().await?;
 
         if let Ok(mut writable_pairs) = self.pairs.write() {
@@ -86,7 +91,7 @@ impl ExchangeInfo {
             }
         }
 
-        Ok(())
+        Ok(self.list_pairs())
     }
 }
 

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     errors::{MissingImplementationContent, OpenLimitError},
     exchange::Exchange,
     exchange_ws::ExchangeWs,
+    exchange_info::{ExchangeInfoRetrieval, ExchangeInfo, MarketPair, MarketPairHandle},
     model::{
         websocket::{OpenLimitsWebsocketMessage, Subscription},
         AskBid, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
@@ -20,6 +21,7 @@ use rust_decimal::prelude::*;
 
 pub struct Nash {
     transport: Client,
+    exchange_info: ExchangeInfo,
 }
 
 impl Nash {
@@ -46,6 +48,7 @@ impl Nash {
             )
             .await
             .unwrap(),
+            exchange_info: ExchangeInfo::new()
         }
     }
 }
@@ -239,9 +242,8 @@ impl Exchange for Nash {
         Ok(resp.order.into())
     }
 
-    async fn refresh_market_info(&self) -> Result<()> {
-        println!("Nash doesn't support refreshing markets");
-        Ok(())
+    async fn refresh_market_info(&self) -> Result<Vec<MarketPairHandle>> {
+        self.exchange_info.refresh(self).await
     }
 }
 
@@ -667,5 +669,36 @@ impl From<nash_protocol::protocol::subscriptions::SubscriptionResponse>
                 OpenLimitsWebsocketMessage::Trades(trades)
             }
         }
+    }
+}
+
+impl Nash {
+    async fn list_markets(&self) -> Result<nash_protocol::protocol::list_markets::ListMarketsResponse> {
+        let response = self.transport.run(
+            nash_protocol::protocol::list_markets::ListMarketsRequest
+        ).await?;
+        if let Some(err) = response.error() {
+            Err(OpenLimitError::NashProtocolError(
+                // FIXME: handle this better in both nash protocol and openlimits
+                nash_protocol::errors::ProtocolError::coerce_static_from_str(&format!("{:#?}", err))
+            ))
+        } else {
+            Ok(response.consume_response().unwrap()) // safe unwrap
+        }
+    }
+}
+
+#[async_trait]
+impl ExchangeInfoRetrieval for Nash {
+    async fn retrieve_pairs(&self) -> Result<Vec<MarketPair>> {
+        Ok(self.list_markets().await?.markets.iter().map(|(symbol,v)| {
+            MarketPair {
+                    symbol: symbol.to_string(),
+                    base: v.asset_b.asset.name().to_string(),
+                    quote: v.asset_a.asset.name().to_string(),
+                    base_increment: Decimal::new(1, v.asset_b.precision),
+                    quote_increment: Decimal::new(1, v.asset_a.precision)
+                }
+        }).collect())
     }
 }

--- a/tests/nash/market.rs
+++ b/tests/nash/market.rs
@@ -1,5 +1,6 @@
 use openlimits::{
     exchange::OpenLimits,
+    exchange_info::ExchangeInfoRetrieval,
     model::{GetHistoricRatesRequest, GetPriceTickerRequest, Interval, OrderBookRequest},
     nash::Nash,
 };
@@ -39,6 +40,13 @@ async fn get_historic_rates() {
     println!("{:?}", resp);
 }
 
+#[tokio::test]
+async fn retrieve_pairs() {
+    let exchange = init().await;
+    let pairs = exchange.refresh_market_info().await.unwrap();
+    println!("{:?}", pairs);
+}
+
 // #[tokio::test]
 // async fn get_historic_rates_invalid_interval() {
 //     let mut exchange = init().await;
@@ -58,7 +66,7 @@ async fn init() -> OpenLimits<Nash> {
         &env::var("NASH_API_SECRET").unwrap(),
         &env::var("NASH_API_KEY").unwrap(),
         1234,
-        true,
+        false,
         100000,
     )
     .await;


### PR DESCRIPTION
* Added list markets request and implemented ExchangeInfoRetrieval via ExchangeInfo for Nash
* Provided market data to openlimits user by returning Vec<MarketPairHandle> when client calls refresh_market_info