### PR TITLE
add support for trade subscription for binance

### DIFF
--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -202,7 +202,7 @@ impl From<TradeMessage> for Trade<String, String> {
             market_pair: trade.symbol,
             price: trade.price,
             qty: trade.qty,
-            fees: Decimal::from(0),
+            fees: Decimal::from(0), // TODO: Binance does not return fee on trades over WS stream
             // https://money.stackexchange.com/questions/90686/what-does-buyer-is-maker-mean/102005#102005
             side: match trade.is_buyer_maker {
                 true => Side::Sell,

--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -4,7 +4,6 @@ mod transport;
 use std::convert::TryFrom;
 
 use client::websocket::BinanceWebsocket;
-use rust_decimal::prelude::Decimal;
 
 use crate::{
     binance::model::websocket::TradeMessage,
@@ -202,7 +201,7 @@ impl From<TradeMessage> for Trade<String, String> {
             market_pair: trade.symbol,
             price: trade.price,
             qty: trade.qty,
-            fees: Decimal::from(0), // TODO: Binance does not return fee on trades over WS stream
+            fees: None, // Binance does not return fee on trades over WS stream
             // https://money.stackexchange.com/questions/90686/what-does-buyer-is-maker-mean/102005#102005
             side: match trade.is_buyer_maker {
                 true => Side::Sell,
@@ -274,7 +273,7 @@ impl From<model::TradeHistory> for Trade<u64, u64> {
             market_pair: trade_history.symbol,
             price: trade_history.price,
             qty: trade_history.qty,
-            fees: trade_history.commission,
+            fees: Some(trade_history.commission),
             side: match trade_history.is_buyer {
                 true => Side::Buy,
                 false => Side::Sell,

--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -3,15 +3,15 @@ pub mod model;
 mod transport;
 use std::convert::TryFrom;
 
-use rust_decimal::prelude::Decimal;
 use client::websocket::BinanceWebsocket;
+use rust_decimal::prelude::Decimal;
 
 use crate::{
+    binance::model::websocket::TradeMessage,
     errors::OpenLimitError,
     exchange::Exchange,
     exchange_info::{ExchangeInfo, MarketPairHandle},
     exchange_ws::ExchangeWs,
-    binance::model::websocket::TradeMessage,
     model::{
         websocket::{OpenLimitsWebsocketMessage, Subscription},
         AskBid, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
@@ -209,7 +209,7 @@ impl From<TradeMessage> for Trade<String, String> {
                 false => Side::Buy,
             },
             liquidity: None,
-            created_at: trade.trade_order_time
+            created_at: trade.trade_order_time,
         }
     }
 }
@@ -418,9 +418,7 @@ impl From<Subscription> for model::websocket::Subscription {
             Subscription::OrderBook(symbol, depth) => {
                 model::websocket::Subscription::OrderBook(symbol, depth)
             }
-            Subscription::Trade(symbol) => {
-                model::websocket::Subscription::Trade(symbol)
-            }
+            Subscription::Trade(symbol) => model::websocket::Subscription::Trade(symbol),
             _ => panic!("Not supported Subscription"),
         }
     }

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -250,7 +250,7 @@ impl From<model::Fill> for Trade<u64, String> {
             market_pair: fill.product_id,
             price: fill.price,
             qty: fill.size,
-            fees: fill.fee,
+            fees: Some(fill.fee),
             side: match fill.side.as_str() {
                 "buy" => Side::Buy,
                 _ => Side::Sell,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -91,7 +91,7 @@ pub struct Trade<T, O> {
     pub market_pair: String,
     pub price: Decimal,
     pub qty: Decimal,
-    pub fees: Decimal,
+    pub fees: Option<Decimal>,
     pub side: Side,
     pub liquidity: Option<Liquidity>,
     pub created_at: u64,

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -405,7 +405,7 @@ impl From<nash_protocol::types::Trade> for Trade<String, String> {
         Self {
             id: resp.id,
             created_at: resp.executed_at.timestamp_millis() as u64,
-            fees,
+            fees: Some(fees),
             liquidity: Some(resp.account_side.into()),
             market_pair: resp.market.market_name(),
             order_id,

--- a/tests/binance/websocket.rs
+++ b/tests/binance/websocket.rs
@@ -13,6 +13,15 @@ async fn orderbook() {
     println!("{:?}", v);
 }
 
+#[tokio::test]
+async fn trades() {
+    let mut ws = init();
+    let sub = Subscription::Trade("btcusdt".to_string());
+    ws.subscribe(sub).await.unwrap();
+    let v = ws.next().await;
+    println!("{:?}", v);
+}
+
 fn init() -> OpenLimitsWs<BinanceWebsocket> {
     OpenLimitsWs {
         websocket: BinanceWebsocket::new(),


### PR DESCRIPTION
Adds support for trades subscription for binance. This is needed for me to start experimenting with rewriting the nash pricing service to rust.