### PR TITLE
Add trades snapshot

### DIFF
--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -14,10 +14,10 @@ use crate::{
     model::{
         websocket::{OpenLimitsWebsocketMessage, Subscription},
         AskBid, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
-        GetHistoricRatesRequest, GetOrderHistoryRequest, GetOrderRequest, GetPriceTickerRequest,
-        Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest, Order,
-        OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, Paginator, Side, Ticker,
-        Trade, TradeHistoryRequest, Transaction,
+        GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
+        GetPriceTickerRequest, Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest,
+        Order, OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, Paginator, Side,
+        Ticker, Trade, TradeHistoryRequest, Transaction,
     },
     shared::Result,
 };
@@ -168,6 +168,13 @@ impl Exchange for Binance {
         Binance::get_klines(self, &params)
             .await
             .map(|KlineSummaries::AllKlineSummaries(v)| v.into_iter().map(Into::into).collect())
+    }
+
+    async fn get_historic_trades(
+        &self,
+        _req: &GetHistoricTradesRequest<Self::PaginationType>,
+    ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>> {
+        unimplemented!("Only implemented for Nash right now");
     }
 
     async fn get_order(

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -8,10 +8,10 @@ use crate::{
     exchange_info::{ExchangeInfo, MarketPairHandle},
     model::{
         AskBid, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
-        GetHistoricRatesRequest, GetOrderHistoryRequest, GetOrderRequest, GetPriceTickerRequest,
-        Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest, Order,
-        OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, Paginator, Side, Ticker,
-        Trade, TradeHistoryRequest,
+        GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
+        GetPriceTickerRequest, Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest,
+        Order, OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, Paginator, Side,
+        Ticker, Trade, TradeHistoryRequest,
     },
     shared::{timestamp_to_naive_datetime, Result},
 };
@@ -170,6 +170,13 @@ impl Exchange for Coinbase {
         Coinbase::candles(self, &req.market_pair, Some(&params))
             .await
             .map(|v| v.into_iter().map(Into::into).collect())
+    }
+
+    async fn get_historic_trades(
+        &self,
+        _req: &GetHistoricTradesRequest<Self::PaginationType>,
+    ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>> {
+        unimplemented!("Only implemented for Nash right now");
     }
 
     async fn get_order(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,13 +43,13 @@ impl fmt::Display for MissingImplementationContent {
 
 #[derive(Error, Debug)]
 pub enum OpenLimitError {
-    #[error("")]
+    #[error(transparent)]
     BinanceError(#[from] BinanceContentError),
-    #[error("")]
+    #[error(transparent)]
     CoinbaseError(#[from] CoinbaseContentError),
-    #[error("")]
+    #[error(transparent)]
     NashProtocolError(#[from] nash_protocol::errors::ProtocolError),
-    #[error("")]
+    #[error(transparent)]
     MissingImplementation(#[from] MissingImplementationContent),
     #[error("")]
     AssetNotFound(),
@@ -67,25 +67,25 @@ pub enum OpenLimitError {
     SocketError(),
     #[error("")]
     GetTimestampFailed(),
-    #[error("")]
+    #[error(transparent)]
     ReqError(#[from] reqwest::Error),
-    #[error("")]
+    #[error(transparent)]
     InvalidHeaderError(#[from] reqwest::header::InvalidHeaderValue),
-    #[error("")]
+    #[error(transparent)]
     InvalidPayloadSignature(#[from] serde_urlencoded::ser::Error),
-    #[error("")]
+    #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error("")]
     PoisonError(),
-    #[error("")]
+    #[error(transparent)]
     JsonError(#[from] serde_json::Error),
-    #[error("")]
+    #[error(transparent)]
     ParseFloatError(#[from] std::num::ParseFloatError),
-    #[error("")]
+    #[error(transparent)]
     UrlParserError(#[from] url::ParseError),
-    #[error("")]
+    #[error(transparent)]
     Tungstenite(#[from] tokio_tungstenite::tungstenite::Error),
-    #[error("")]
+    #[error(transparent)]
     TimestampError(#[from] std::time::SystemTimeError),
     #[error("")]
     UnkownResponse(String),

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -5,9 +5,9 @@ use crate::{
     exchange_info::MarketPairHandle,
     model::{
         Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle, GetHistoricRatesRequest,
-        GetOrderHistoryRequest, GetOrderRequest, GetPriceTickerRequest, OpenLimitOrderRequest,
-        OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse, OrderCanceled,
-        Paginator, Ticker, Trade, TradeHistoryRequest,
+        GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest, GetPriceTickerRequest,
+        OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse,
+        OrderCanceled, Paginator, Ticker, Trade, TradeHistoryRequest,
     },
     shared::Result,
 };
@@ -88,6 +88,13 @@ impl<E: Exchange> OpenLimits<E> {
         self.exchange.get_historic_rates(req).await
     }
 
+    pub async fn get_historic_trades(
+        &self,
+        req: &GetHistoricTradesRequest<E::PaginationType>,
+    ) -> Result<Vec<Trade<E::TradeIdType, E::OrderIdType>>> {
+        self.exchange.get_historic_trades(req).await
+    }
+
     pub async fn get_order(
         &self,
         req: GetOrderRequest<E::OrderIdType>,
@@ -137,6 +144,10 @@ pub trait Exchange {
         &self,
         req: &GetHistoricRatesRequest<Self::PaginationType>,
     ) -> Result<Vec<Candle>>;
+    async fn get_historic_trades(
+        &self,
+        req: &GetHistoricTradesRequest<Self::PaginationType>,
+    ) -> Result<Vec<Trade<Self::TradeIdType, Self::OrderIdType>>>;
     async fn get_order(
         &self,
         req: &GetOrderRequest<Self::OrderIdType>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -144,6 +144,12 @@ pub struct GetHistoricRatesRequest<T> {
     pub interval: Interval,
 }
 
+#[derive(Serialize, Deserialize, Clone, Constructor, Debug)]
+pub struct GetHistoricTradesRequest<T> {
+    pub market_pair: String,
+    pub paginator: Option<Paginator<T>>,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Side {
     Buy,

--- a/src/model/websocket.rs
+++ b/src/model/websocket.rs
@@ -1,7 +1,7 @@
 use super::{OrderBookResponse, Trade};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Subscription {
     UserData(String),            // listen key
     AggregateTrade(String),      // symbol

--- a/tests/nash/market.rs
+++ b/tests/nash/market.rs
@@ -1,7 +1,10 @@
 use openlimits::{
     exchange::OpenLimits,
     exchange_info::ExchangeInfoRetrieval,
-    model::{GetHistoricRatesRequest, GetPriceTickerRequest, Interval, OrderBookRequest},
+    model::{
+        GetHistoricRatesRequest, GetHistoricTradesRequest, GetPriceTickerRequest,
+        Interval, OrderBookRequest, Paginator
+    },
     nash::Nash,
 };
 
@@ -37,6 +40,20 @@ async fn get_historic_rates() {
         paginator: None,
     };
     let resp = exchange.get_historic_rates(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_historic_trades() {
+    let exchange = init().await;
+    let req = GetHistoricTradesRequest {
+        market_pair: "eth_btc".to_string(),
+        paginator: Some(Paginator {
+            limit: Some(100),
+            ..Default::default()
+        }),
+    };
+    let resp = exchange.get_historic_trades(&req).await.unwrap();
     println!("{:?}", resp);
 }
 


### PR DESCRIPTION
We don't need to merge this yet. Just wanted to make a start here
Contents so far:
- add trades snapshot method. I'll make a corresponding PR to nash-rust too (https://github.com/nash-io/nash-rust/pull/19)
- convenience public/private instantiation methods that I needed in the C++ wrapper. I see that there's already work towards a unified interface, so these methods are probably not needed in the future