### PR TITLE
Enum that implements traits for any supported exchange type

### DIFF
--- a/src/any_exchange.rs
+++ b/src/any_exchange.rs
@@ -3,10 +3,10 @@
 //! use to operate over any openlimits-supported exchange without generics
 
 use crate::binance::{Binance, BinanceParameters, BinanceWebsocket};
+use crate::exchange::{Exchange, ExchangeAccount, ExchangeMarketData};
 use crate::exchange_info::{ExchangeInfoRetrieval, MarketPair, MarketPairHandle};
 use crate::exchange_ws::{ExchangeWs, OpenLimitsWs};
 use crate::nash::{Nash, NashParameters, NashStream};
-use crate::exchange::{ExchangeAccount, Exchange, ExchangeMarketData};
 use crate::{
     model::{
         websocket::{OpenLimitsWebsocketMessage, Subscription},
@@ -17,9 +17,9 @@ use crate::{
     },
     shared::Result,
 };
-use std::{pin::Pin, task::Context, task::Poll};
-use futures::stream::{Stream, StreamExt};
 use async_trait::async_trait;
+use futures::stream::{Stream, StreamExt};
+use std::{pin::Pin, task::Context, task::Poll};
 
 #[derive(Clone)]
 pub enum InitAnyExchange {

--- a/src/any_exchange.rs
+++ b/src/any_exchange.rs
@@ -1,0 +1,134 @@
+//! In some contexts, such as bindings in other languages (e.g., Python via pyo3) it is not possible to use trait
+//! constraints on generics. This module provides an enum wrapper type for all openlimits exchanges that code can 
+//! use to operate over any openlimits exchange without generics
+
+use crate::{
+    model::{
+        Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle, GetHistoricRatesRequest,
+        GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest, GetPriceTickerRequest,
+        OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse,
+        OrderCanceled, Paginator, Ticker, Trade, TradeHistoryRequest,
+    },
+    shared::Result,
+};
+use crate::nash::{NashParameters, Nash, NashStream, Client as NashBaseClient};
+use crate::binance::{BinanceParameters, Binance, BinanceWebsocket, BaseClient as BinanceBaseClient};
+use crate::exchange::{Exchange, ExchangeAccount, ExchangeMarketData};
+use crate::exchange_ws::{ExchangeWs, OpenLimitsWs};
+use crate::exchange_info::{ExchangeInfo, ExchangeInfoRetrieval};
+use async_trait::async_trait;
+
+
+
+pub enum AnyCredential {
+    Nash(NashParameters),
+    Binance(BinanceParameters)
+}
+
+pub enum OpenlimitsAnyExchange {
+    Nash(Nash),
+    Binance(Binance),
+}
+
+#[async_trait]
+impl Exchange for OpenlimitsAnyExchange {
+    type InitParams = AnyCredential;
+    type InnerClient = ();
+    async fn new(params: AnyCredential) -> Self {
+        match params {
+            AnyCredential::Nash(params) => Nash::new(params).await.into(),
+            AnyCredential::Binance(params) => Binance::new(params).await.into()
+        }
+    }
+    // not particularly useful to access the inner client with this type. could wrap the inner
+    // client reference in an enum, but that would introduce lifetimes all the way down due to
+    // https://users.rust-lang.org/t/how-to-specify-lifetime-for-associated-type/5736 
+    fn inner_client(&self) -> Option<&Self::InnerClient> { None }
+}
+
+#[async_trait]
+impl ExchangeAccount for OpenlimitsAnyExchange {
+    async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
+        match self {
+            Self::Nash(nash) => nash.limit_buy(req).await,
+            Self::Binance(binance) => binance.limit_buy(req).await
+        }
+    }
+    async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
+        match self {
+            Self::Nash(nash) => nash.limit_sell(req).await,
+            Self::Binance(binance) => binance.limit_sell(req).await
+        }
+    }
+    async fn market_buy(&self, req: &OpenMarketOrderRequest) -> Result<Order> {
+        match self {
+            Self::Nash(nash) => nash.market_buy(req).await,
+            Self::Binance(binance) => binance.market_buy(req).await
+        }
+    }
+    async fn market_sell(&self, req: &OpenMarketOrderRequest) -> Result<Order> {
+        match self {
+            Self::Nash(nash) => nash.market_sell(req).await,
+            Self::Binance(binance) => binance.market_sell(req).await
+        }
+    }
+    async fn cancel_order(&self, req: &CancelOrderRequest) -> Result<OrderCanceled> {
+        match self {
+            Self::Nash(nash) => nash.cancel_order(req).await,
+            Self::Binance(binance) => binance.cancel_order(req).await
+        }
+    }
+    async fn cancel_all_orders(&self, req: &CancelAllOrdersRequest) -> Result<Vec<OrderCanceled>> {
+        match self {
+            Self::Nash(nash) => nash.cancel_all_orders(req).await,
+            Self::Binance(binance) => binance.cancel_all_orders(req).await
+        }
+    }
+    async fn get_all_open_orders(&self) -> Result<Vec<Order>> {
+        match self {
+            Self::Nash(nash) => nash.get_all_open_orders().await,
+            Self::Binance(binance) => binance.get_all_open_orders().await
+        }
+    }
+    async fn get_order_history(&self, req: &GetOrderHistoryRequest) -> Result<Vec<Order>> {
+        match self {
+            Self::Nash(nash) => nash.get_order_history(req).await,
+            Self::Binance(binance) => binance.get_order_history(req).await
+        }
+    }
+    async fn get_trade_history(&self, req: &TradeHistoryRequest) -> Result<Vec<Trade>> {
+        match self {
+            Self::Nash(nash) => nash.get_trade_history(req).await,
+            Self::Binance(binance) => binance.get_trade_history(req).await
+        }
+    }
+    async fn get_account_balances(&self, paginator: Option<Paginator>) -> Result<Vec<Balance>> {
+        match self {
+            Self::Nash(nash) => nash.get_account_balances(paginator).await,
+            Self::Binance(binance) => binance.get_account_balances(paginator).await
+        }
+    }
+    async fn get_order(&self, req: &GetOrderRequest) -> Result<Order> {
+        match self {
+            Self::Nash(nash) => nash.get_order(req).await,
+            Self::Binance(binance) => binance.get_order(req).await
+        }
+    }
+}
+
+pub enum OpenLimitsAnyWs {
+    Nash(OpenLimitsWs<NashStream>),
+    Binance(OpenLimitsWs<BinanceWebsocket>)
+}
+
+impl From<Nash> for OpenlimitsAnyExchange {
+    fn from(nash: Nash) -> Self {
+        Self::Nash(nash)
+    }
+}
+
+impl From<Binance> for OpenlimitsAnyExchange {
+    fn from(binance: Binance) -> Self {
+        Self::Binance(binance)
+    }
+}

--- a/src/any_exchange.rs
+++ b/src/any_exchange.rs
@@ -16,16 +16,10 @@ use crate::{
     },
     shared::Result,
 };
-use crate::nash::{NashParameters, Nash, NashStream};
-use crate::binance::{BinanceParameters, Binance, BinanceWebsocket};
-use crate::exchange::{Exchange, ExchangeAccount, ExchangeMarketData};
-use crate::exchange_ws::{ExchangeWs, OpenLimitsWs};
 use crate::exchange_info::{ExchangeInfoRetrieval, MarketPair, MarketPairHandle};
 use std::{pin::Pin, task::Context, task::Poll};
 use futures::stream::{Stream, StreamExt};
 use async_trait::async_trait;
-use futures::stream::{Stream, StreamExt};
-use std::{pin::Pin, task::Context, task::Poll};
 
 #[derive(Clone)]
 pub enum InitAnyExchange {

--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -21,11 +21,11 @@ use crate::{
     shared::Result,
 };
 use async_trait::async_trait;
-use client::websocket::BinanceWebsocket;
+pub use client::websocket::BinanceWebsocket;
 use model::KlineSummaries;
 use transport::Transport;
 
-use client::BaseClient;
+pub use client::BaseClient;
 
 #[derive(Clone)]
 pub struct Binance {
@@ -91,8 +91,8 @@ impl Exchange for Binance {
         binance
     }
 
-    fn inner_client(&self) -> &Self::InnerClient {
-        &self.client
+    fn inner_client(&self) -> Option<&Self::InnerClient> {
+        Some(&self.client)
     }
 }
 

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -90,8 +90,8 @@ impl Exchange for Coinbase {
         coinbase
     }
 
-    fn inner_client(&self) -> &Self::InnerClient {
-        &self.client
+    fn inner_client(&self) -> Option<&Self::InnerClient> {
+        Some(&self.client)
     }
 }
 

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -25,7 +25,7 @@ pub trait Exchange {
     type InitParams;
     type InnerClient;
     async fn new(params: Self::InitParams) -> Self;
-    fn inner_client(&self) -> &Self::InnerClient;
+    fn inner_client(&self) -> Option<&Self::InnerClient>;
 }
 
 #[async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,3 +29,4 @@ pub mod exchange_ws;
 pub mod model;
 pub mod nash;
 pub mod shared;
+pub mod any_exchange;

--- a/src/model/python.rs
+++ b/src/model/python.rs
@@ -1,11 +1,106 @@
 use super::super::model::{Interval, Paginator};
 use super::websocket::{OpenLimitsWebsocketMessage, Subscription};
+use super::super::nash::{NashParameters, NashCredentials, Environment};
+use super::super::binance::{BinanceParameters, BinanceCredentials};
+use super::super::any_exchange::InitAnyExchange;
 
 use pyo3::exceptions::PyException;
 use pyo3::prelude::{FromPyObject, IntoPy, PyObject, PyResult, Python, ToPyObject};
 use pyo3::types::PyDict;
 
 // Python to Rust...
+
+impl<'a> FromPyObject<'a> for InitAnyExchange {
+    fn extract(ob: &'a pyo3::PyAny) -> PyResult<Self> {
+        // unfortunately can't do the if let on the extract() since it needs type annotations
+        let maybe_nash: PyResult<NashParameters> = ob.extract();
+        if let Ok(nash) = maybe_nash {
+            return Ok(InitAnyExchange::Nash(nash))
+        } 
+        let maybe_binance: PyResult<BinanceParameters> = ob.extract();
+        if let Ok(binance) = maybe_binance {
+            return Ok(InitAnyExchange::Binance(binance))
+        }
+        Err(PyException::new_err("invalid exchange initialization params"))
+    }
+}
+
+impl<'a> FromPyObject<'a> for BinanceCredentials {
+    fn extract(ob: &'a pyo3::PyAny) -> PyResult<Self> {
+        let py_dict = ob.get_item("binance_credentials")?.downcast::<PyDict>()?;
+        let api_key: String = py_dict.get_item("api_key").ok_or(
+            PyException::new_err("secret not included in binance credentials")
+        )?.extract()?;
+        let api_secret: String = py_dict.get_item("api_secret").ok_or(
+            PyException::new_err("session not included in binance credentials")
+        )?.extract()?;
+        Ok(BinanceCredentials{
+            api_key,
+            api_secret
+        })
+    }
+}
+
+impl<'a> FromPyObject<'a> for BinanceParameters {
+    fn extract(ob: &'a pyo3::PyAny) -> PyResult<Self> {
+        let py_dict = ob.get_item("binance")?.downcast::<PyDict>()?;
+        let credentials: Option<BinanceCredentials> = py_dict.get_item("credentials").ok_or(
+            PyException::new_err("credentials not included in binance params")
+        )?.extract()?;
+        let sandbox: bool = py_dict.get_item("sandbox").ok_or(
+            PyException::new_err("session not included in binance credentials")
+        )?.extract()?;
+        Ok(BinanceParameters {
+            sandbox,
+            credentials
+        })
+    }
+}
+
+impl<'a> FromPyObject<'a> for NashCredentials {
+    fn extract(ob: &'a pyo3::PyAny) -> PyResult<Self> {
+        let py_dict = ob.get_item("nash_credentials")?.downcast::<PyDict>()?;
+        let secret: String = py_dict.get_item("secret").ok_or(
+            PyException::new_err("secret not included in nash credentials")
+        )?.extract()?;
+        let session: String = py_dict.get_item("session").ok_or(
+            PyException::new_err("session not included in nash credentials")
+        )?.extract()?;
+        Ok(NashCredentials{
+            secret,
+            session
+        })
+    }
+}
+
+impl<'a> FromPyObject<'a> for NashParameters {
+    fn extract(ob: &'a pyo3::PyAny) -> PyResult<Self> {
+        let py_dict = ob.get_item("nash")?.downcast::<PyDict>()?;
+        let credentials: Option<NashCredentials> = py_dict.get_item("credentials").ok_or(
+            PyException::new_err("credentials not included in nash params")
+        )?.extract()?;
+        let client_id: u64 = py_dict.get_item("client_id").ok_or(
+            PyException::new_err("session not included in nash credentials")
+        )?.extract()?;
+        let env_str: String = py_dict.get_item("environment").ok_or(
+            PyException::new_err("session not included in nash credentials")
+        )?.extract()?;
+        let environment = match &env_str[..] {
+            "sandbox" => Ok(Environment::Sandbox),
+            "production" => Ok(Environment::Production),
+            _ => Err(PyException::new_err("not a valid nash environment"))
+        }?;
+        let timeout: u64 = py_dict.get_item("timeout").ok_or(
+            PyException::new_err("timeout not included in nash credentials")
+        )?.extract()?;
+        Ok(NashParameters{
+            credentials,
+            client_id,
+            environment,
+            timeout
+        })
+    }
+}
 
 impl<'a> FromPyObject<'a> for Interval {
     fn extract(ob: &'a pyo3::PyAny) -> PyResult<Self> {

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use nash_native_client::ws_client::client::Client;
+pub use nash_native_client::ws_client::client::Client;
 use std::convert::{TryFrom, TryInto};
 
 use crate::{
@@ -80,8 +80,8 @@ impl Exchange for Nash {
         }
     }
 
-    fn inner_client(&self) -> &Self::InnerClient {
-        &self.transport
+    fn inner_client(&self) -> Option<&Self::InnerClient> {
+        Some(&self.transport)
     }
 }
 

--- a/tests/apis/binance/account.rs
+++ b/tests/apis/binance/account.rs
@@ -14,14 +14,14 @@ use openlimits::{
 #[tokio::test]
 async fn get_account() {
     let exchange = init().await;
-    let resp = exchange.inner_client().get_account().await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_account().await.unwrap();
     println!("{:?}", resp);
 }
 
 #[tokio::test]
 async fn get_balance() {
     let exchange = init().await;
-    let resp = exchange.inner_client().get_balance("BTC").await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_balance("BTC").await.unwrap();
     println!("{:?}", resp);
 }
 
@@ -29,7 +29,7 @@ async fn get_balance() {
 async fn get_open_orders() {
     let exchange = init().await;
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_open_orders("BNBBTC")
         .await
         .unwrap();
@@ -39,7 +39,7 @@ async fn get_open_orders() {
 #[tokio::test]
 async fn get_all_open_orders() {
     let exchange = init().await;
-    let resp = exchange.inner_client().get_all_open_orders().await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_all_open_orders().await.unwrap();
     println!("{:?}", resp);
 }
 
@@ -51,7 +51,7 @@ async fn get_all_orders() {
         symbol: String::from("BNBBTC"),
     };
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_all_orders(&params)
         .await
         .unwrap();
@@ -63,12 +63,12 @@ async fn get_order() {
     let exchange = init().await;
     let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();
     let transaction = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3))
         .await
         .unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_order("BNBBTC", transaction.order_id)
         .await
         .unwrap();
@@ -80,7 +80,7 @@ async fn limit_buy() {
     let exchange = init().await;
     let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_buy(pair, Decimal::new(1, 1), Decimal::new(1, 3))
         .await
         .unwrap();
@@ -92,7 +92,7 @@ async fn rounded_limit_buy() {
     let exchange = init().await;
     let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_buy(pair, Decimal::new(12345678, 8), Decimal::new(1, 3))
         .await
         .unwrap();
@@ -104,7 +104,7 @@ async fn limit_sell() {
     let exchange = init().await;
     let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3))
         .await
         .unwrap();
@@ -116,7 +116,7 @@ async fn market_buy() {
     let exchange = init().await;
     let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .market_buy(pair, Decimal::new(1, 0))
         .await
         .unwrap();
@@ -128,7 +128,7 @@ async fn market_sell() {
     let exchange = init().await;
     let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .market_sell(pair, Decimal::new(1, 0))
         .await
         .unwrap();
@@ -141,12 +141,12 @@ async fn cancel_order() {
     let exchange = init().await;
     let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();
     let transaction = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3))
         .await
         .unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .cancel_order("BNBBTC", transaction.order_id)
         .await
         .unwrap();
@@ -162,7 +162,7 @@ async fn trade_history() {
     };
 
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .trade_history(&params)
         .await
         .unwrap();

--- a/tests/apis/binance/general.rs
+++ b/tests/apis/binance/general.rs
@@ -6,18 +6,18 @@ use openlimits::{
 #[tokio::test]
 async fn ping() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
-    assert_eq!("pong", exchange.inner_client().ping().await.unwrap());
+    assert_eq!("pong", exchange.inner_client().unwrap().ping().await.unwrap());
 }
 
 #[tokio::test]
 async fn get_server_time() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
-    exchange.inner_client().get_server_time().await.unwrap();
+    exchange.inner_client().unwrap().get_server_time().await.unwrap();
 }
 
 #[tokio::test]
 async fn get_exchange_info() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
-    let resp = exchange.inner_client().get_exchange_info().await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_exchange_info().await.unwrap();
     println!("{:?}", resp);
 }

--- a/tests/apis/binance/market.rs
+++ b/tests/apis/binance/market.rs
@@ -7,7 +7,7 @@ use openlimits::{
 async fn get_depth() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_depth("BNBBTC", 50)
         .await
         .unwrap();
@@ -17,14 +17,14 @@ async fn get_depth() {
 #[tokio::test]
 async fn get_all_prices() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
-    let resp = exchange.inner_client().get_all_prices().await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_all_prices().await.unwrap();
     println!("{:?}", resp);
 }
 
 #[tokio::test]
 async fn get_price() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
-    let resp = exchange.inner_client().get_price("BNBBTC").await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_price("BNBBTC").await.unwrap();
     println!("{:?}", resp);
 }
 
@@ -32,7 +32,7 @@ async fn get_price() {
 async fn get_all_book_tickers() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_all_book_tickers()
         .await
         .unwrap();
@@ -43,7 +43,7 @@ async fn get_all_book_tickers() {
 async fn get_book_ticker() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_book_ticker("BNBBTC")
         .await
         .unwrap();
@@ -54,7 +54,7 @@ async fn get_book_ticker() {
 async fn get_24h_price_stats() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_24h_price_stats("BNBBTC")
         .await
         .unwrap();
@@ -69,7 +69,7 @@ async fn get_klines() {
         interval: String::from("5m"),
         paginator: None,
     };
-    let resp = exchange.inner_client().get_klines(&params).await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_klines(&params).await.unwrap();
     println!("{:?}", resp);
 }
 
@@ -77,7 +77,7 @@ async fn get_klines() {
 async fn get_24h_price_stats_all() {
     let exchange = Binance::new(BinanceParameters::sandbox()).await;
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_24h_price_stats_all()
         .await
         .unwrap();

--- a/tests/apis/coinbase/account.rs
+++ b/tests/apis/coinbase/account.rs
@@ -14,7 +14,7 @@ use openlimits::{
 #[tokio::test]
 async fn get_account() {
     let exchange = init().await;
-    let resp = exchange.inner_client().get_account(None).await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_account(None).await.unwrap();
     println!("{:?}", resp);
 }
 
@@ -27,7 +27,7 @@ async fn get_all_open_orders() {
         product_id: None,
     };
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_orders(Some(&params))
         .await
         .unwrap();
@@ -37,7 +37,7 @@ async fn get_all_open_orders() {
 #[tokio::test]
 async fn get_all_orders() {
     let exchange = init().await;
-    let resp = exchange.inner_client().get_orders(None).await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_orders(None).await.unwrap();
     println!("{:?}", resp);
 
     // let params = GetOrderRequest{
@@ -58,7 +58,7 @@ async fn get_all_orders_for_a_given_product() {
     };
 
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_orders(Some(&params))
         .await
         .unwrap();
@@ -70,12 +70,12 @@ async fn get_order() {
     let exchange = init().await;
     let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
     let order = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .market_buy(pair, Decimal::new(1, 3))
         .await
         .unwrap();
 
-    let resp = exchange.inner_client().get_order(order.id).await.unwrap();
+    let resp = exchange.inner_client().unwrap().get_order(order.id).await.unwrap();
     println!("{:?}", resp);
 }
 
@@ -84,7 +84,7 @@ async fn limit_buy() {
     let exchange = init().await;
     let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_buy(pair, Decimal::new(1, 3), Decimal::new(5000, 0))
         .await
         .unwrap();
@@ -96,7 +96,7 @@ async fn limit_sell() {
     let exchange = init().await;
     let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_sell(pair, Decimal::new(1, 3), Decimal::new(20000, 0))
         .await
         .unwrap();
@@ -108,7 +108,7 @@ async fn market_buy() {
     let exchange = init().await;
     let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .market_buy(pair, Decimal::new(1, 3))
         .await
         .unwrap();
@@ -120,7 +120,7 @@ async fn market_sell() {
     let exchange = init().await;
     let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .market_sell(pair, Decimal::new(1, 3))
         .await
         .unwrap();
@@ -132,24 +132,24 @@ async fn cancel_all_orders() {
     let exchange = init().await;
     let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
     exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(20000, 0))
         .await
         .unwrap();
     exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(20000, 0))
         .await
         .unwrap();
 
     exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_buy(pair, Decimal::new(2, 2), Decimal::new(2, 2))
         .await
         .unwrap();
 
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .cancel_all_orders(Some("BTC-USD"))
         .await
         .unwrap();
@@ -157,7 +157,7 @@ async fn cancel_all_orders() {
     println!("{:?}", resp);
 
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .cancel_all_orders(None)
         .await
         .unwrap();
@@ -170,12 +170,12 @@ async fn cancel_order() {
     let exchange = init().await;
     let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
     let order = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .limit_sell(pair, Decimal::new(1, 3), Decimal::new(20000, 0))
         .await
         .unwrap();
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .cancel_order(order.id, Some("BTC-USD"))
         .await
         .unwrap();
@@ -188,7 +188,7 @@ async fn get_fills_for_order() {
     let exchange = init().await;
     let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
     let order = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .market_sell(pair, Decimal::new(1, 3))
         .await
         .unwrap();
@@ -200,7 +200,7 @@ async fn get_fills_for_order() {
     };
 
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_fills(Some(&params))
         .await
         .unwrap();
@@ -218,7 +218,7 @@ async fn get_fills_for_product() {
     };
 
     let resp = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .get_fills(Some(&params))
         .await
         .unwrap();

--- a/tests/apis/coinbase/market.rs
+++ b/tests/apis/coinbase/market.rs
@@ -10,14 +10,14 @@ use openlimits::{
 #[tokio::test]
 async fn products() {
     let exchange = Coinbase::new(CoinbaseParameters::sandbox()).await;
-    let res = exchange.inner_client().products().await.unwrap();
+    let res = exchange.inner_client().unwrap().products().await.unwrap();
     println!("{:?}", res);
 }
 
 #[tokio::test]
 async fn product() {
     let exchange = Coinbase::new(CoinbaseParameters::sandbox()).await;
-    let res = exchange.inner_client().product("BTC-USD").await.unwrap();
+    let res = exchange.inner_client().unwrap().product("BTC-USD").await.unwrap();
     println!("{:?}", res);
 }
 
@@ -25,7 +25,7 @@ async fn product() {
 async fn trades() {
     let exchange = Coinbase::new(CoinbaseParameters::sandbox()).await;
     let res = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .trades("BTC-USD", None)
         .await
         .unwrap();
@@ -34,7 +34,7 @@ async fn trades() {
     let trade = res.last().unwrap();
 
     let res = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .trades(
             "BTC-USD",
             Some(&Paginator {
@@ -52,7 +52,7 @@ async fn trades() {
 async fn book() {
     let exchange = Coinbase::new(CoinbaseParameters::sandbox()).await;
     let res = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .book::<BookRecordL1>("BTC-USD")
         .await
         .unwrap();
@@ -62,7 +62,7 @@ async fn book() {
 #[tokio::test]
 async fn ticker() {
     let exchange = Coinbase::new(CoinbaseParameters::sandbox()).await;
-    let res = exchange.inner_client().ticker("BTC-USD").await.unwrap();
+    let res = exchange.inner_client().unwrap().ticker("BTC-USD").await.unwrap();
     println!("{:?}", res);
 }
 
@@ -70,14 +70,14 @@ async fn ticker() {
 async fn candles() {
     let exchange = Coinbase::new(CoinbaseParameters::sandbox()).await;
     let res = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .candles("BTC-USD", None)
         .await
         .unwrap();
     println!("{:?}", res);
 
     let res = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .candles(
             "BTC-USD",
             Some(&CandleRequestParams {
@@ -93,7 +93,7 @@ async fn candles() {
             .unwrap();
 
     let res = exchange
-        .inner_client()
+        .inner_client().unwrap()
         .candles(
             "BTC-USD",
             Some(&CandleRequestParams {


### PR DESCRIPTION
In some contexts, such as bindings in other languages (e.g., Python via pyo3), it is not possible to use generics like `fn init<T: Exchange>(){ ... }`. This makes it difficult to write general logic that can operate over dynamically instantiated exchange types. This module provides an enum wrapper type that code can use in these cases