### PR TITLE
add support for time in force for Nash,Binance and Coinbase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ python = ["pyo3"]
 [dependencies]
 async-trait = "0.1"
 base64 = "0.12.3"
-chrono = "0.4.11"
+chrono = { version = "0.4.11", features = ["serde"] }
 dotenv = "0.15.0"
 futures = "0.3.5"
 hex = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ python = ["pyo3"]
 [dependencies]
 async-trait = "0.1"
 base64 = "0.12.3"
-chrono = { version = "0.4.11", features = ["serde"] }
+chrono = { version = "0.4.11", features = ["std", "serde"] }
 dotenv = "0.15.0"
 futures = "0.3.5"
 hex = "0.4.2"

--- a/src/binance/client/account.rs
+++ b/src/binance/client/account.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 use super::BaseClient;
 use crate::{
     binance::model::{
+        TimeInForce,
         AccountInformation, AllOrderReq, Balance, Order, OrderCanceled, OrderRequest, TradeHistory,
         TradeHistoryReq, ORDER_SIDE_BUY, ORDER_SIDE_SELL, ORDER_TYPE_LIMIT, ORDER_TYPE_MARKET,
-        TIME_IN_FORCE_GTC,
     },
     errors::OpenLimitError,
     exchange_info::MarketPair,
@@ -80,7 +80,7 @@ impl BaseClient {
     }
 
     // Place a LIMIT order - BUY
-    pub async fn limit_buy(&self, pair: MarketPair, qty: Decimal, price: Decimal) -> Result<Order> {
+    pub async fn limit_buy(&self, pair: MarketPair, qty: Decimal, price: Decimal, tif: TimeInForce) -> Result<Order> {
         let buy: OrderRequest = OrderRequest {
             symbol: pair.symbol,
             quantity: qty.round_dp(pair.base_increment.normalize().scale()),
@@ -90,7 +90,7 @@ impl BaseClient {
             )),
             order_side: ORDER_SIDE_BUY.to_string(),
             order_type: ORDER_TYPE_LIMIT.to_string(),
-            time_in_force: Some(TIME_IN_FORCE_GTC.to_string()),
+            time_in_force: Some(tif),
         };
 
         let transaction = self
@@ -108,6 +108,7 @@ impl BaseClient {
         pair: MarketPair,
         qty: Decimal,
         price: Decimal,
+        tif: TimeInForce
     ) -> Result<Order> {
         let sell: OrderRequest = OrderRequest {
             symbol: pair.symbol,
@@ -118,7 +119,7 @@ impl BaseClient {
             )),
             order_side: ORDER_SIDE_SELL.to_string(),
             order_type: ORDER_TYPE_LIMIT.to_string(),
-            time_in_force: Some(TIME_IN_FORCE_GTC.to_string()),
+            time_in_force: Some(tif),
         };
 
         let transaction = self

--- a/src/binance/client/account.rs
+++ b/src/binance/client/account.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 use super::BaseClient;
 use crate::{
     binance::model::{
-        TimeInForce,
-        AccountInformation, AllOrderReq, Balance, Order, OrderCanceled, OrderRequest, TradeHistory,
-        TradeHistoryReq, ORDER_SIDE_BUY, ORDER_SIDE_SELL, ORDER_TYPE_LIMIT, ORDER_TYPE_MARKET,
+        AccountInformation, AllOrderReq, Balance, Order, OrderCanceled, OrderRequest, TimeInForce,
+        TradeHistory, TradeHistoryReq, ORDER_SIDE_BUY, ORDER_SIDE_SELL, ORDER_TYPE_LIMIT,
+        ORDER_TYPE_MARKET,
     },
     errors::OpenLimitError,
     exchange_info::MarketPair,
@@ -80,7 +80,13 @@ impl BaseClient {
     }
 
     // Place a LIMIT order - BUY
-    pub async fn limit_buy(&self, pair: MarketPair, qty: Decimal, price: Decimal, tif: TimeInForce) -> Result<Order> {
+    pub async fn limit_buy(
+        &self,
+        pair: MarketPair,
+        qty: Decimal,
+        price: Decimal,
+        tif: TimeInForce,
+    ) -> Result<Order> {
         let buy: OrderRequest = OrderRequest {
             symbol: pair.symbol,
             quantity: qty.round_dp(pair.base_increment.normalize().scale()),
@@ -108,7 +114,7 @@ impl BaseClient {
         pair: MarketPair,
         qty: Decimal,
         price: Decimal,
-        tif: TimeInForce
+        tif: TimeInForce,
     ) -> Result<Order> {
         let sell: OrderRequest = OrderRequest {
             symbol: pair.symbol,

--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -476,7 +476,7 @@ impl From<TimeInForce> for model::TimeInForce {
             TimeInForce::GoodTillCancelled => model::TimeInForce::GTC,
             TimeInForce::FillOrKill => model::TimeInForce::FOK,
             TimeInForce::ImmediateOrCancelled => model::TimeInForce::IOC,
-            TimeInForce::GoodTillTime(_) => {
+            _ => {
                 panic!("Binance does not support GoodTillTime policy")
             }
         }

--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
         GetPriceTickerRequest, Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest,
         Order, OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, OrderType,
-        Paginator, Side, Ticker, Trade, TradeHistoryRequest, Transaction,
+        Paginator, Side, Ticker, Trade, TradeHistoryRequest, Transaction, TimeInForce
     },
     shared::Result,
 };
@@ -187,14 +187,14 @@ impl ExchangeAccount for Binance {
     async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
         let pair = self.exchange_info.get_pair(&req.market_pair)?.read()?;
         self.client
-            .limit_buy(pair, req.size, req.price)
+            .limit_buy(pair, req.size, req.price, model::TimeInForce::from(req.time_in_force))
             .await
             .map(Into::into)
     }
     async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
         let pair = self.exchange_info.get_pair(&req.market_pair)?.read()?;
         self.client
-            .limit_sell(pair, req.size, req.price)
+            .limit_sell(pair, req.size, req.price, model::TimeInForce::from(req.time_in_force))
             .await
             .map(Into::into)
     }
@@ -466,6 +466,19 @@ impl From<model::KlineSummary> for Candle {
             open: kline_summary.open,
             close: kline_summary.close,
             volume: kline_summary.volume,
+        }
+    }
+}
+
+impl From<TimeInForce> for model::TimeInForce {
+    fn from(tif: TimeInForce) -> Self {
+        match tif {
+            TimeInForce::GoodTillCancelled => model::TimeInForce::GTC,
+            TimeInForce::FillOrKill => model::TimeInForce::FOK,
+            TimeInForce::ImmediateOrCancelled => model::TimeInForce::IOC,
+            TimeInForce::GoodTillTime(_) => {
+                panic!("Binance does not support GoodTillTime policy")
+            }
         }
     }
 }

--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -239,7 +239,7 @@ impl ExchangeAccount for Binance {
         }
     }
     async fn get_all_open_orders(&self) -> Result<Vec<Order>> {
-        Binance::get_all_open_orders(&self)
+        self.client.get_all_open_orders()
             .await
             .map(|v| v.into_iter().map(Into::into).collect())
     }

--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
         GetPriceTickerRequest, Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest,
         Order, OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, OrderType,
-        Paginator, Side, Ticker, Trade, TradeHistoryRequest, Transaction, TimeInForce
+        Paginator, Side, Ticker, TimeInForce, Trade, TradeHistoryRequest, Transaction,
     },
     shared::Result,
 };
@@ -187,14 +187,24 @@ impl ExchangeAccount for Binance {
     async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
         let pair = self.exchange_info.get_pair(&req.market_pair)?.read()?;
         self.client
-            .limit_buy(pair, req.size, req.price, model::TimeInForce::from(req.time_in_force))
+            .limit_buy(
+                pair,
+                req.size,
+                req.price,
+                model::TimeInForce::from(req.time_in_force),
+            )
             .await
             .map(Into::into)
     }
     async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
         let pair = self.exchange_info.get_pair(&req.market_pair)?.read()?;
         self.client
-            .limit_sell(pair, req.size, req.price, model::TimeInForce::from(req.time_in_force))
+            .limit_sell(
+                pair,
+                req.size,
+                req.price,
+                model::TimeInForce::from(req.time_in_force),
+            )
             .await
             .map(Into::into)
     }
@@ -239,7 +249,8 @@ impl ExchangeAccount for Binance {
         }
     }
     async fn get_all_open_orders(&self) -> Result<Vec<Order>> {
-        self.client.get_all_open_orders()
+        self.client
+            .get_all_open_orders()
             .await
             .map(|v| v.into_iter().map(Into::into).collect())
     }
@@ -476,9 +487,7 @@ impl From<TimeInForce> for model::TimeInForce {
             TimeInForce::GoodTillCancelled => model::TimeInForce::GTC,
             TimeInForce::FillOrKill => model::TimeInForce::FOK,
             TimeInForce::ImmediateOrCancelled => model::TimeInForce::IOC,
-            _ => {
-                panic!("Binance does not support GoodTillTime policy")
-            }
+            _ => panic!("Binance does not support GoodTillTime policy"),
         }
     }
 }

--- a/src/binance/model/mod.rs
+++ b/src/binance/model/mod.rs
@@ -88,7 +88,7 @@ pub struct OrderRequest {
     #[serde(rename = "type")]
     pub order_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub time_in_force: Option<String>,
+    pub time_in_force: Option<TimeInForce>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/binance/model/mod.rs
+++ b/src/binance/model/mod.rs
@@ -422,7 +422,6 @@ pub enum OrderType {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TimeInForce {
     GTC,
     IOC,

--- a/src/coinbase/client/account.rs
+++ b/src/coinbase/client/account.rs
@@ -74,6 +74,7 @@ impl BaseClient {
         size: Decimal,
         price: Decimal,
         time_in_force: OrderTimeInForce,
+        post_only: bool
     ) -> Result<Order> {
         let data = OrderRequest {
             product_id: pair.symbol,
@@ -85,7 +86,7 @@ impl BaseClient {
                     pair.quote_increment.normalize().scale(),
                     RoundingStrategy::RoundDown,
                 ),
-                post_only: true,
+                post_only,
                 time_in_force: Some(time_in_force),
             },
             stop: None,
@@ -105,6 +106,7 @@ impl BaseClient {
         size: Decimal,
         price: Decimal,
         time_in_force: OrderTimeInForce,
+        post_only: bool
     ) -> Result<Order> {
         let data = OrderRequest {
             product_id: pair.symbol,
@@ -116,7 +118,7 @@ impl BaseClient {
                     pair.quote_increment.normalize().scale(),
                     RoundingStrategy::RoundUp,
                 ),
-                post_only: true,
+                post_only,
                 time_in_force: Some(time_in_force),
             },
             stop: None,

--- a/src/coinbase/client/account.rs
+++ b/src/coinbase/client/account.rs
@@ -2,7 +2,8 @@ use super::BaseClient;
 use crate::{
     coinbase::model::{
         Account, CancelAllOrders, CancelOrder, Fill, GetFillsReq, GetOrderRequest, Order,
-        OrderRequest, OrderRequestMarketType, OrderRequestType, OrderSide, Paginator, OrderTimeInForce
+        OrderRequest, OrderRequestMarketType, OrderRequestType, OrderSide, OrderTimeInForce,
+        Paginator,
     },
     exchange_info::MarketPair,
     shared::Result,
@@ -74,7 +75,7 @@ impl BaseClient {
         size: Decimal,
         price: Decimal,
         time_in_force: OrderTimeInForce,
-        post_only: bool
+        post_only: bool,
     ) -> Result<Order> {
         let data = OrderRequest {
             product_id: pair.symbol,
@@ -106,7 +107,7 @@ impl BaseClient {
         size: Decimal,
         price: Decimal,
         time_in_force: OrderTimeInForce,
-        post_only: bool
+        post_only: bool,
     ) -> Result<Order> {
         let data = OrderRequest {
             product_id: pair.symbol,

--- a/src/coinbase/client/account.rs
+++ b/src/coinbase/client/account.rs
@@ -2,7 +2,7 @@ use super::BaseClient;
 use crate::{
     coinbase::model::{
         Account, CancelAllOrders, CancelOrder, Fill, GetFillsReq, GetOrderRequest, Order,
-        OrderRequest, OrderRequestMarketType, OrderRequestType, OrderSide, Paginator,
+        OrderRequest, OrderRequestMarketType, OrderRequestType, OrderSide, Paginator, OrderTimeInForce
     },
     exchange_info::MarketPair,
     shared::Result,
@@ -73,6 +73,7 @@ impl BaseClient {
         pair: MarketPair,
         size: Decimal,
         price: Decimal,
+        time_in_force: OrderTimeInForce,
     ) -> Result<Order> {
         let data = OrderRequest {
             product_id: pair.symbol,
@@ -85,7 +86,7 @@ impl BaseClient {
                     RoundingStrategy::RoundDown,
                 ),
                 post_only: true,
-                time_in_force: None,
+                time_in_force: Some(time_in_force),
             },
             stop: None,
         };
@@ -103,6 +104,7 @@ impl BaseClient {
         pair: MarketPair,
         size: Decimal,
         price: Decimal,
+        time_in_force: OrderTimeInForce,
     ) -> Result<Order> {
         let data = OrderRequest {
             product_id: pair.symbol,
@@ -115,7 +117,7 @@ impl BaseClient {
                     RoundingStrategy::RoundUp,
                 ),
                 post_only: true,
-                time_in_force: None,
+                time_in_force: Some(time_in_force),
             },
             stop: None,
         };

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     shared::{timestamp_to_naive_datetime, Result},
 };
 use async_trait::async_trait;
-
+use chrono::Duration;
 use client::BaseClient;
 use std::convert::TryFrom;
 use transport::Transport;
@@ -427,13 +427,34 @@ impl From<&Paginator> for model::DateRange {
     }
 }
 
+
 impl From<TimeInForce> for model::OrderTimeInForce {
     fn from(tif: TimeInForce) -> Self {
         match tif {
             TimeInForce::GoodTillCancelled => model::OrderTimeInForce::GTC,
             TimeInForce::FillOrKill => model::OrderTimeInForce::FOK,
             TimeInForce::ImmediateOrCancelled => model::OrderTimeInForce::IOC,
-            TimeInForce::GoodTillTime(expire_time) => model::OrderTimeInForce::GTT { expire_time: expire_time.to_rfc2822() },
+            TimeInForce::GoodTillTime(duration) => {
+                let day: Duration = Duration::days(1);
+                let hour: Duration = Duration::hours(1);
+                let minute: Duration = Duration::minutes(1);
+
+                if duration == day {
+                    model::OrderTimeInForce::GTT {
+                        cancel_after: model::CancelAfter::Day
+                    }
+                } else if duration == hour {
+                    model::OrderTimeInForce::GTT {
+                        cancel_after: model::CancelAfter::Hour
+                    }
+                } else if duration == minute {
+                    model::OrderTimeInForce::GTT {
+                        cancel_after: model::CancelAfter::Hour
+                    }
+                } else {
+                    panic!("Coinbase only supports durations of 1 day, 1 hour or 1 minute")
+                }
+            },
         }
     }
 }

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
         GetPriceTickerRequest, Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest,
         Order, OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, OrderType,
-        Paginator, Side, Ticker, Trade, TradeHistoryRequest, TimeInForce
+        Paginator, Side, Ticker, TimeInForce, Trade, TradeHistoryRequest,
     },
     shared::{timestamp_to_naive_datetime, Result},
 };
@@ -197,7 +197,13 @@ impl ExchangeAccount for Coinbase {
     async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
         let pair = self.exchange_info.get_pair(&req.market_pair)?.read()?;
         self.client
-            .limit_buy(pair, req.size, req.price, model::OrderTimeInForce::from(req.time_in_force.clone()), false)
+            .limit_buy(
+                pair,
+                req.size,
+                req.price,
+                model::OrderTimeInForce::from(req.time_in_force.clone()),
+                false,
+            )
             .await
             .map(Into::into)
     }
@@ -205,7 +211,13 @@ impl ExchangeAccount for Coinbase {
     async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
         let pair = self.exchange_info.get_pair(&req.market_pair)?.read()?;
         self.client
-            .limit_sell(pair, req.size, req.price, model::OrderTimeInForce::from(req.time_in_force.clone()), false)
+            .limit_sell(
+                pair,
+                req.size,
+                req.price,
+                model::OrderTimeInForce::from(req.time_in_force.clone()),
+                false,
+            )
             .await
             .map(Into::into)
     }
@@ -427,7 +439,6 @@ impl From<&Paginator> for model::DateRange {
     }
 }
 
-
 impl From<TimeInForce> for model::OrderTimeInForce {
     fn from(tif: TimeInForce) -> Self {
         match tif {
@@ -441,20 +452,20 @@ impl From<TimeInForce> for model::OrderTimeInForce {
 
                 if duration == day {
                     model::OrderTimeInForce::GTT {
-                        cancel_after: model::CancelAfter::Day
+                        cancel_after: model::CancelAfter::Day,
                     }
                 } else if duration == hour {
                     model::OrderTimeInForce::GTT {
-                        cancel_after: model::CancelAfter::Hour
+                        cancel_after: model::CancelAfter::Hour,
                     }
                 } else if duration == minute {
                     model::OrderTimeInForce::GTT {
-                        cancel_after: model::CancelAfter::Hour
+                        cancel_after: model::CancelAfter::Hour,
                     }
                 } else {
                     panic!("Coinbase only supports durations of 1 day, 1 hour or 1 minute")
                 }
-            },
+            }
         }
     }
 }

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -197,7 +197,7 @@ impl ExchangeAccount for Coinbase {
     async fn limit_buy(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
         let pair = self.exchange_info.get_pair(&req.market_pair)?.read()?;
         self.client
-            .limit_buy(pair, req.size, req.price, model::OrderTimeInForce::from(req.time_in_force.clone()))
+            .limit_buy(pair, req.size, req.price, model::OrderTimeInForce::from(req.time_in_force.clone()), false)
             .await
             .map(Into::into)
     }
@@ -205,7 +205,7 @@ impl ExchangeAccount for Coinbase {
     async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
         let pair = self.exchange_info.get_pair(&req.market_pair)?.read()?;
         self.client
-            .limit_sell(pair, req.size, req.price, model::OrderTimeInForce::from(req.time_in_force.clone()))
+            .limit_sell(pair, req.size, req.price, model::OrderTimeInForce::from(req.time_in_force.clone()), false)
             .await
             .map(Into::into)
     }

--- a/src/coinbase/model/mod.rs
+++ b/src/coinbase/model/mod.rs
@@ -3,8 +3,8 @@ use crate::shared::{
 };
 use serde::{Deserialize, Serialize};
 pub mod websocket;
-use chrono::naive::NaiveDateTime;
 use rust_decimal::prelude::Decimal;
+use chrono::naive::NaiveDateTime;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Product {
@@ -222,7 +222,7 @@ pub enum OrderType {
         #[serde(with = "string_to_decimal")]
         price: Decimal,
         #[serde(flatten)]
-        time_in_force: OrderTimeInForce,
+        time_in_force: OrderTimeInForceResponse,
     },
     Market {
         #[serde(default)]
@@ -283,9 +283,30 @@ pub struct GetFillsReq {
 #[serde(tag = "time_in_force")]
 pub enum OrderTimeInForce {
     GTC,
-    GTT { expire_time: String },
+    GTT { cancel_after: CancelAfter },
     IOC,
     FOK,
+}
+
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "time_in_force")]
+pub enum OrderTimeInForceResponse {
+    GTC,
+    GTT {
+        #[serde(with = "naive_datetime_from_string")]
+        expire_time: NaiveDateTime
+    },
+    IOC,
+    FOK,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum CancelAfter {
+    Min,
+    Hour,
+    Day,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/coinbase/model/mod.rs
+++ b/src/coinbase/model/mod.rs
@@ -3,8 +3,8 @@ use crate::shared::{
 };
 use serde::{Deserialize, Serialize};
 pub mod websocket;
-use rust_decimal::prelude::Decimal;
 use chrono::naive::NaiveDateTime;
+use rust_decimal::prelude::Decimal;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Product {
@@ -288,14 +288,13 @@ pub enum OrderTimeInForce {
     FOK,
 }
 
-
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "time_in_force")]
 pub enum OrderTimeInForceResponse {
     GTC,
     GTT {
         #[serde(with = "naive_datetime_from_string")]
-        expire_time: NaiveDateTime
+        expire_time: NaiveDateTime,
     },
     IOC,
     FOK,

--- a/src/coinbase/transport.rs
+++ b/src/coinbase/transport.rs
@@ -248,6 +248,7 @@ impl Transport {
             StatusCode::OK => {
                 let text = response.text().await?;
                 serde_json::from_str::<O>(&text).map_err(move |err| {
+                    println!("{}", &text);
                     OpenLimitError::NotParsableResponse(format!("Error:{} Payload: {}", err, text))
                 })
             }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,7 +1,10 @@
 use chrono::Duration;
 use derive_more::Constructor;
 use rust_decimal::prelude::Decimal;
-use serde::{de::{self, Visitor}, Deserialize, Deserializer, Serializer, Serialize};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use std::fmt;
 
 #[cfg(feature = "python")]
@@ -36,7 +39,6 @@ pub enum TimeInForce {
     GoodTillTime(Duration),
 }
 
-
 // chrono::Duration does not have a serde serialize/deserialize option
 struct TimeInForceVisitor;
 
@@ -48,18 +50,19 @@ impl<'de> Visitor<'de> for TimeInForceVisitor {
     }
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
     where
-            E: de::Error {
+        E: de::Error,
+    {
         if v.starts_with("GTT,") {
             match v[4..].parse::<u64>() {
                 Ok(v) => Ok(TimeInForce::GoodTillTime(Duration::milliseconds(v as i64))),
-                _ => Err(E::custom(format!("Invalid GTG: {}", v)))
+                _ => Err(E::custom(format!("Invalid GTG: {}", v))),
             }
         } else {
             match v {
                 "GTC" => Ok(TimeInForce::GoodTillCancelled),
                 "IOC" => Ok(TimeInForce::ImmediateOrCancelled),
                 "FOK" => Ok(TimeInForce::FillOrKill),
-                _ => Err(E::custom(format!("Invalid string: {}", v)))
+                _ => Err(E::custom(format!("Invalid string: {}", v))),
             }
         }
     }
@@ -83,14 +86,16 @@ impl Serialize for TimeInForce {
             TimeInForce::GoodTillCancelled => String::from("GTC"),
             TimeInForce::ImmediateOrCancelled => String::from("IOC"),
             TimeInForce::FillOrKill => String::from("FOK"),
-            TimeInForce::GoodTillTime(d) => format!("GTT,{}", d.num_milliseconds())
+            TimeInForce::GoodTillTime(d) => format!("GTT,{}", d.num_milliseconds()),
         };
         serializer.serialize_str(s.as_str())
     }
 }
 
 impl Default for TimeInForce {
-    fn default() -> Self { TimeInForce::GoodTillCancelled }
+    fn default() -> Self {
+        TimeInForce::GoodTillCancelled
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
@@ -325,7 +330,6 @@ pub enum OrderType {
     Unknown,
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::TimeInForce;
@@ -338,6 +342,5 @@ mod tests {
         println!("serialized = {}", serialized);
         let deserialized: TimeInForce = serde_json::from_str(&serialized).unwrap();
         println!("deserialized = {:?}", deserialized);
-        
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,4 @@
-use chrono::Duration;
+use chrono::{Duration, DateTime, Utc};
 use derive_more::Constructor;
 use rust_decimal::prelude::Decimal;
 use serde::{Deserialize, Serialize};
@@ -26,11 +26,25 @@ pub struct AskBid {
     pub qty: Decimal,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Copy)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TimeInForce {
+    GoodTillCancelled,
+    ImmediateOrCancelled,
+    FillOrKill,
+    GoodTillTime(DateTime<Utc>),
+}
+
+impl Default for TimeInForce {
+    fn default() -> Self { TimeInForce::GoodTillCancelled }
+}
+
 #[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]
 pub struct OpenLimitOrderRequest {
     pub market_pair: String,
     pub size: Decimal,
     pub price: Decimal,
+    pub time_in_force: TimeInForce,
 }
 
 #[derive(Serialize, Deserialize, Clone, Constructor, Debug, Default, PartialEq)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,7 +1,8 @@
-use chrono::{Duration, DateTime, Utc};
+use chrono::Duration;
 use derive_more::Constructor;
 use rust_decimal::prelude::Decimal;
-use serde::{Deserialize, Serialize};
+use serde::{de::{self, Visitor}, Deserialize, Deserializer, Serializer, Serialize};
+use std::fmt;
 
 #[cfg(feature = "python")]
 pub mod python;
@@ -26,13 +27,66 @@ pub struct AskBid {
     pub qty: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Copy)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Clone, Debug, PartialEq, Copy)]
 pub enum TimeInForce {
     GoodTillCancelled,
     ImmediateOrCancelled,
     FillOrKill,
-    GoodTillTime(DateTime<Utc>),
+    // Representing 'good till time' as a duration works for both Nash and Coinbase
+    GoodTillTime(Duration),
+}
+
+
+// chrono::Duration does not have a serde serialize/deserialize option
+struct TimeInForceVisitor;
+
+impl<'de> Visitor<'de> for TimeInForceVisitor {
+    type Value = TimeInForce;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an string, either GTC, IOC, FOK, GTT,duration")
+    }
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+            E: de::Error {
+        if v.starts_with("GTT,") {
+            match v[4..].parse::<u64>() {
+                Ok(v) => Ok(TimeInForce::GoodTillTime(Duration::milliseconds(v as i64))),
+                _ => Err(E::custom(format!("Invalid GTG: {}", v)))
+            }
+        } else {
+            match v {
+                "GTC" => Ok(TimeInForce::GoodTillCancelled),
+                "IOC" => Ok(TimeInForce::ImmediateOrCancelled),
+                "FOK" => Ok(TimeInForce::FillOrKill),
+                _ => Err(E::custom(format!("Invalid string: {}", v)))
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TimeInForce {
+    fn deserialize<D>(deserializer: D) -> Result<TimeInForce, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(TimeInForceVisitor)
+    }
+}
+
+impl Serialize for TimeInForce {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = match *self {
+            TimeInForce::GoodTillCancelled => String::from("GTC"),
+            TimeInForce::ImmediateOrCancelled => String::from("IOC"),
+            TimeInForce::FillOrKill => String::from("FOK"),
+            TimeInForce::GoodTillTime(d) => format!("GTT,{}", d.num_milliseconds())
+        };
+        serializer.serialize_str(s.as_str())
+    }
 }
 
 impl Default for TimeInForce {
@@ -269,4 +323,21 @@ pub enum OrderType {
     StopLimit,
     StopMarket,
     Unknown,
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::TimeInForce;
+    use chrono::Duration;
+
+    #[test]
+    fn can_serialize_time_in_force() {
+        let t = TimeInForce::GoodTillTime(Duration::hours(1));
+        let serialized = serde_json::to_string(&t).unwrap();
+        println!("serialized = {}", serialized);
+        let deserialized: TimeInForce = serde_json::from_str(&serialized).unwrap();
+        println!("deserialized = {:?}", deserialized);
+        
+    }
 }

--- a/src/model/python.rs
+++ b/src/model/python.rs
@@ -20,9 +20,9 @@ impl<'a> FromPyObject<'a> for TimeInForce {
                 "good_til_cancelled" => Ok(TimeInForce::GoodTillCancelled),
                 "immediate_or_cancelled" => Ok(TimeInForce::ImmediateOrCancelled),
                 "fill_or_kill" => Ok(TimeInForce::FillOrKill),
-                _ => Err(PyException::new_err("Invalid time in force"))
+                _ => Err(PyException::new_err("Invalid time in force")),
             }
-        }        
+        }
     }
 }
 

--- a/src/model/python.rs
+++ b/src/model/python.rs
@@ -1,14 +1,30 @@
 use super::super::any_exchange::InitAnyExchange;
 use super::super::binance::{BinanceCredentials, BinanceParameters};
-use super::super::model::{Interval, Paginator};
+use super::super::model::{Interval, Paginator, TimeInForce};
 use super::super::nash::{Environment, NashCredentials, NashParameters};
 use super::websocket::{OpenLimitsWebsocketMessage, Subscription};
-
 use pyo3::exceptions::PyException;
 use pyo3::prelude::{FromPyObject, IntoPy, PyObject, PyResult, Python, ToPyObject};
 use pyo3::types::PyDict;
 
 // Python to Rust...
+
+impl<'a> FromPyObject<'a> for TimeInForce {
+    fn extract(ob: &'a pyo3::PyAny) -> PyResult<Self> {
+        let maybe_interval: PyResult<Interval> = ob.get_item("time_in_force")?.extract();
+        if let Ok(interval) = maybe_interval {
+            Ok(TimeInForce::GoodTillTime(interval.into()))
+        } else {
+            let value: String = ob.get_item("time_in_force")?.extract()?;
+            match &value[..] {
+                "good_til_cancelled" => Ok(TimeInForce::GoodTillCancelled),
+                "immediate_or_cancelled" => Ok(TimeInForce::ImmediateOrCancelled),
+                "fill_or_kill" => Ok(TimeInForce::FillOrKill),
+                _ => Err(PyException::new_err("Invalid time in force"))
+            }
+        }        
+    }
+}
 
 impl<'a> FromPyObject<'a> for InitAnyExchange {
     fn extract(ob: &'a pyo3::PyAny) -> PyResult<Self> {
@@ -133,23 +149,23 @@ impl<'a> FromPyObject<'a> for NashParameters {
 
 impl<'a> FromPyObject<'a> for Interval {
     fn extract(ob: &'a pyo3::PyAny) -> PyResult<Self> {
-        let interval_str: String = ob.get_item("interval")?.extract()?;
+        let interval_str: String = ob.extract()?;
         match &interval_str[..] {
-            "one_minute" => Ok(Interval::OneMinute),
-            "three_minutes" => Ok(Interval::ThreeMinutes),
-            "five_minutes" => Ok(Interval::FiveMinutes),
-            "fifteen_minutes" => Ok(Interval::FifteenMinutes),
-            "thirty_minutes" => Ok(Interval::ThirtyMinutes),
-            "one_hour" => Ok(Interval::OneHour),
-            "two_hours" => Ok(Interval::TwoHours),
-            "four_hours" => Ok(Interval::FourHours),
-            "six_hours" => Ok(Interval::SixHours),
-            "eight_hours" => Ok(Interval::EightHours),
-            "twelve_hours" => Ok(Interval::TwelveHours),
-            "one_day" => Ok(Interval::OneDay),
-            "three_days" => Ok(Interval::ThreeDays),
-            "one_week" => Ok(Interval::OneWeek),
-            "one_month" => Ok(Interval::OneMonth),
+            "1m" => Ok(Interval::OneMinute),
+            "3m" => Ok(Interval::ThreeMinutes),
+            "5m" => Ok(Interval::FiveMinutes),
+            "15m" => Ok(Interval::FifteenMinutes),
+            "30m" => Ok(Interval::ThirtyMinutes),
+            "1h" => Ok(Interval::OneHour),
+            "2h" => Ok(Interval::TwoHours),
+            "4h" => Ok(Interval::FourHours),
+            "6h" => Ok(Interval::SixHours),
+            "8h" => Ok(Interval::EightHours),
+            "12h" => Ok(Interval::TwelveHours),
+            "1d" => Ok(Interval::OneDay),
+            "3d" => Ok(Interval::ThreeDays),
+            "1w" => Ok(Interval::OneWeek),
+            "1mo" => Ok(Interval::OneMonth),
             _ => Err(PyException::new_err("Interval value not supported")),
         }
     }

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     shared::{timestamp_to_utc_datetime, Result},
 };
 use rust_decimal::prelude::*;
-
+use chrono::Utc;
 pub use nash_native_client::ws_client::client::Environment;
 
 pub struct Nash {
@@ -763,7 +763,10 @@ impl From<TimeInForce>
             TimeInForce::GoodTillCancelled => nash_protocol::types::OrderCancellationPolicy::GoodTilCancelled,
             TimeInForce::FillOrKill => nash_protocol::types::OrderCancellationPolicy::FillOrKill,
             TimeInForce::ImmediateOrCancelled => nash_protocol::types::OrderCancellationPolicy::ImmediateOrCancel,
-            TimeInForce::GoodTillTime(expire_time) => nash_protocol::types::OrderCancellationPolicy::GoodTilTime(expire_time.clone()),
+            TimeInForce::GoodTillTime(duration)  => {
+                let expire_time = Utc::now() + duration;
+                nash_protocol::types::OrderCancellationPolicy::GoodTilTime(expire_time.clone())
+            },
         }
     }
 }

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -288,13 +288,12 @@ impl Nash {
         req: &OpenLimitOrderRequest,
         buy_or_sell: nash_protocol::types::BuyOrSell,
     ) -> nash_protocol::protocol::place_order::LimitOrderRequest {
-        let market = nash_protocol::types::Market::from_str(&req.market_pair).unwrap();
         nash_protocol::protocol::place_order::LimitOrderRequest {
             cancellation_policy: nash_protocol::types::OrderCancellationPolicy::from(
                 req.time_in_force,
             ),
             allow_taker: true,
-            market,
+            market: req.market_pair.clone(),
             buy_or_sell,
             amount: format!("{}", req.size),
             price: format!("{}", req.price),

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -235,7 +235,6 @@ impl ExchangeAccount for Nash {
     async fn limit_sell(&self, req: &OpenLimitOrderRequest) -> Result<Order> {
         let req: nash_protocol::protocol::place_order::LimitOrderRequest =
             Nash::convert_limit_order(req, nash_protocol::types::BuyOrSell::Sell);
-
         let resp = self.transport.run(req).await;
 
         Ok(
@@ -289,8 +288,7 @@ impl Nash {
         req: &OpenLimitOrderRequest,
         buy_or_sell: nash_protocol::types::BuyOrSell,
     ) -> nash_protocol::protocol::place_order::LimitOrderRequest {
-        let market = req.market_pair.clone();
-
+        let market = nash_protocol::types::Market::from_str(&req.market_pair).unwrap();
         nash_protocol::protocol::place_order::LimitOrderRequest {
             cancellation_policy: nash_protocol::types::OrderCancellationPolicy::from(req.time_in_force),
             allow_taker: true,

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -17,13 +17,13 @@ use crate::{
         GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
         GetPriceTickerRequest, Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest,
         Order, OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, OrderType,
-        Paginator, Side, Ticker, Trade, TradeHistoryRequest, TimeInForce
+        Paginator, Side, Ticker, TimeInForce, Trade, TradeHistoryRequest,
     },
     shared::{timestamp_to_utc_datetime, Result},
 };
-use rust_decimal::prelude::*;
 use chrono::Utc;
 pub use nash_native_client::ws_client::client::Environment;
+use rust_decimal::prelude::*;
 
 pub struct Nash {
     transport: Client,
@@ -290,7 +290,9 @@ impl Nash {
     ) -> nash_protocol::protocol::place_order::LimitOrderRequest {
         let market = nash_protocol::types::Market::from_str(&req.market_pair).unwrap();
         nash_protocol::protocol::place_order::LimitOrderRequest {
-            cancellation_policy: nash_protocol::types::OrderCancellationPolicy::from(req.time_in_force),
+            cancellation_policy: nash_protocol::types::OrderCancellationPolicy::from(
+                req.time_in_force,
+            ),
             allow_taker: true,
             market,
             buy_or_sell,
@@ -753,18 +755,20 @@ impl From<nash_protocol::protocol::subscriptions::SubscriptionResponse>
     }
 }
 
-impl From<TimeInForce>
-    for nash_protocol::types::OrderCancellationPolicy
-{
+impl From<TimeInForce> for nash_protocol::types::OrderCancellationPolicy {
     fn from(tif: TimeInForce) -> Self {
         match tif {
-            TimeInForce::GoodTillCancelled => nash_protocol::types::OrderCancellationPolicy::GoodTilCancelled,
+            TimeInForce::GoodTillCancelled => {
+                nash_protocol::types::OrderCancellationPolicy::GoodTilCancelled
+            }
             TimeInForce::FillOrKill => nash_protocol::types::OrderCancellationPolicy::FillOrKill,
-            TimeInForce::ImmediateOrCancelled => nash_protocol::types::OrderCancellationPolicy::ImmediateOrCancel,
-            TimeInForce::GoodTillTime(duration)  => {
+            TimeInForce::ImmediateOrCancelled => {
+                nash_protocol::types::OrderCancellationPolicy::ImmediateOrCancel
+            }
+            TimeInForce::GoodTillTime(duration) => {
                 let expire_time = Utc::now() + duration;
                 nash_protocol::types::OrderCancellationPolicy::GoodTilTime(expire_time.clone())
-            },
+            }
         }
     }
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -52,7 +52,6 @@ pub mod string_to_opt_decimal {
         enum StringToOptDecimal {
             String(Option<String>),
         }
-
         let StringToOptDecimal::String(s) = StringToOptDecimal::deserialize(deserializer)?;
         if let Some(s) = s {
             return Decimal::from_str(&s).map(Some).or(Ok(None));
@@ -85,8 +84,11 @@ pub mod naive_datetime_from_string {
         }
 
         let DatetimeFromString::String(s) = DatetimeFromString::deserialize(deserializer)?;
-
-        NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S.%fZ").map_err(serde::de::Error::custom)
+        let a = NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S.%fZ");
+        match a {
+            Ok(t) => return Ok(t),
+            Err(e) => NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%SZ").map_err(serde::de::Error::custom),
+        }
     }
 }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -87,7 +87,8 @@ pub mod naive_datetime_from_string {
         let a = NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S.%fZ");
         match a {
             Ok(t) => return Ok(t),
-            Err(e) => NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%SZ").map_err(serde::de::Error::custom),
+            Err(e) => NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%SZ")
+                .map_err(serde::de::Error::custom),
         }
     }
 }

--- a/tests/apis/binance/account.rs
+++ b/tests/apis/binance/account.rs
@@ -134,6 +134,32 @@ async fn limit_sell() {
 }
 
 #[tokio::test]
+async fn limit_sell_fok() {
+    let exchange = init().await;
+    let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();
+    let resp = exchange
+        .inner_client()
+        .unwrap()
+        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::FOK)
+        .await
+        .unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn limit_sell_ioc() {
+    let exchange = init().await;
+    let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();
+    let resp = exchange
+        .inner_client()
+        .unwrap()
+        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::IOC)
+        .await
+        .unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
 async fn market_buy() {
     let exchange = init().await;
     let pair = exchange.get_pair("BNBBTC").await.unwrap().read().unwrap();

--- a/tests/apis/binance/account.rs
+++ b/tests/apis/binance/account.rs
@@ -4,7 +4,7 @@ use std::env;
 
 use openlimits::{
     binance::{
-        model::{AllOrderReq, TradeHistoryReq},
+        model::{AllOrderReq, TradeHistoryReq, TimeInForce},
         Binance, BinanceCredentials, BinanceParameters,
     },
     exchange::Exchange,
@@ -82,7 +82,7 @@ async fn get_order() {
     let transaction = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3))
+        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::GTC)
         .await
         .unwrap();
     let resp = exchange
@@ -101,7 +101,7 @@ async fn limit_buy() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(1, 1), Decimal::new(1, 3))
+        .limit_buy(pair, Decimal::new(1, 1), Decimal::new(1, 3), TimeInForce::GTC)
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -114,7 +114,7 @@ async fn rounded_limit_buy() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(12345678, 8), Decimal::new(1, 3))
+        .limit_buy(pair, Decimal::new(12345678, 8), Decimal::new(1, 3), TimeInForce::GTC)
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -127,7 +127,7 @@ async fn limit_sell() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3))
+        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::GTC)
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -167,7 +167,7 @@ async fn cancel_order() {
     let transaction = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3))
+        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::GTC)
         .await
         .unwrap();
     let resp = exchange

--- a/tests/apis/binance/account.rs
+++ b/tests/apis/binance/account.rs
@@ -4,7 +4,7 @@ use std::env;
 
 use openlimits::{
     binance::{
-        model::{AllOrderReq, TradeHistoryReq, TimeInForce},
+        model::{AllOrderReq, TimeInForce, TradeHistoryReq},
         Binance, BinanceCredentials, BinanceParameters,
     },
     exchange::Exchange,
@@ -82,7 +82,12 @@ async fn get_order() {
     let transaction = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::GTC)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 1),
+            Decimal::new(2, 3),
+            TimeInForce::GTC,
+        )
         .await
         .unwrap();
     let resp = exchange
@@ -101,7 +106,12 @@ async fn limit_buy() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(1, 1), Decimal::new(1, 3), TimeInForce::GTC)
+        .limit_buy(
+            pair,
+            Decimal::new(1, 1),
+            Decimal::new(1, 3),
+            TimeInForce::GTC,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -114,7 +124,12 @@ async fn rounded_limit_buy() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(12345678, 8), Decimal::new(1, 3), TimeInForce::GTC)
+        .limit_buy(
+            pair,
+            Decimal::new(12345678, 8),
+            Decimal::new(1, 3),
+            TimeInForce::GTC,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -127,7 +142,12 @@ async fn limit_sell() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::GTC)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 1),
+            Decimal::new(2, 3),
+            TimeInForce::GTC,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -140,7 +160,12 @@ async fn limit_sell_fok() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::FOK)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 1),
+            Decimal::new(2, 3),
+            TimeInForce::FOK,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -153,7 +178,12 @@ async fn limit_sell_ioc() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::IOC)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 1),
+            Decimal::new(2, 3),
+            TimeInForce::IOC,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -193,7 +223,12 @@ async fn cancel_order() {
     let transaction = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 1), Decimal::new(2, 3), TimeInForce::GTC)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 1),
+            Decimal::new(2, 3),
+            TimeInForce::GTC,
+        )
         .await
         .unwrap();
     let resp = exchange

--- a/tests/apis/coinbase/account.rs
+++ b/tests/apis/coinbase/account.rs
@@ -4,7 +4,7 @@ use std::env;
 
 use openlimits::{
     coinbase::{
-        model::{GetFillsReq, GetOrderRequest},
+        model::{GetFillsReq, GetOrderRequest, OrderTimeInForce},
         Coinbase, CoinbaseCredentials, CoinbaseParameters,
     },
     exchange::Exchange,
@@ -104,7 +104,7 @@ async fn limit_buy() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(1, 3), Decimal::new(5000, 0))
+        .limit_buy(pair, Decimal::new(1, 3), Decimal::new(5000, 0), OrderTimeInForce::GTC)
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -117,7 +117,7 @@ async fn limit_sell() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(20000, 0))
+        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(20000, 0), OrderTimeInForce::GTC)
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -156,20 +156,20 @@ async fn cancel_all_orders() {
     exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(20000, 0))
+        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(20000, 0), OrderTimeInForce::GTC)
         .await
         .unwrap();
     exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(20000, 0))
+        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(20000, 0), OrderTimeInForce::GTC)
         .await
         .unwrap();
 
     exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(2, 2), Decimal::new(2, 2))
+        .limit_buy(pair, Decimal::new(2, 2), Decimal::new(2, 2), OrderTimeInForce::GTC)
         .await
         .unwrap();
 
@@ -199,7 +199,7 @@ async fn cancel_order() {
     let order = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(20000, 0))
+        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(20000, 0), OrderTimeInForce::GTC)
         .await
         .unwrap();
     let resp = exchange

--- a/tests/apis/coinbase/account.rs
+++ b/tests/apis/coinbase/account.rs
@@ -4,7 +4,7 @@ use std::env;
 
 use openlimits::{
     coinbase::{
-        model::{GetFillsReq, GetOrderRequest, OrderTimeInForce},
+        model::{GetFillsReq, GetOrderRequest, OrderTimeInForce, CancelAfter},
         Coinbase, CoinbaseCredentials, CoinbaseParameters,
     },
     exchange::Exchange,
@@ -118,6 +118,47 @@ async fn limit_sell() {
         .inner_client()
         .unwrap()
         .limit_sell(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTC, false)
+        .await
+        .unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn limit_sell_fok() {
+    let exchange = init().await;
+    let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
+    let resp = exchange
+        .inner_client()
+        .unwrap()
+        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::FOK, false)
+        .await
+        .unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn limit_sell_ioc() {
+    let exchange = init().await;
+    let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
+    let resp = exchange
+        .inner_client()
+        .unwrap()
+        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::IOC, false)
+        .await
+        .unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn limit_sell_gtt() {
+    let exchange = init().await;
+    let pair = exchange.get_pair("BTC-USD").await.unwrap().read().unwrap();
+    let resp = exchange
+        .inner_client()
+        .unwrap()
+        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTT {
+            cancel_after: CancelAfter::Day
+        }, false)
         .await
         .unwrap();
     println!("{:?}", resp);

--- a/tests/apis/coinbase/account.rs
+++ b/tests/apis/coinbase/account.rs
@@ -104,7 +104,7 @@ async fn limit_buy() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(1, 3), Decimal::new(5000, 0), OrderTimeInForce::GTC)
+        .limit_buy(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTC, false)
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -117,7 +117,7 @@ async fn limit_sell() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(20000, 0), OrderTimeInForce::GTC)
+        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTC, false)
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -156,20 +156,20 @@ async fn cancel_all_orders() {
     exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(20000, 0), OrderTimeInForce::GTC)
+        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTC, false)
         .await
         .unwrap();
     exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(20000, 0), OrderTimeInForce::GTC)
+        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTC, false)
         .await
         .unwrap();
 
     exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(2, 2), Decimal::new(2, 2), OrderTimeInForce::GTC)
+        .limit_buy(pair, Decimal::new(2, 2), Decimal::new(2, 2), OrderTimeInForce::GTC, false)
         .await
         .unwrap();
 
@@ -199,7 +199,7 @@ async fn cancel_order() {
     let order = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(20000, 0), OrderTimeInForce::GTC)
+        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(100000, 0), OrderTimeInForce::GTC, false)
         .await
         .unwrap();
     let resp = exchange

--- a/tests/apis/coinbase/account.rs
+++ b/tests/apis/coinbase/account.rs
@@ -4,7 +4,7 @@ use std::env;
 
 use openlimits::{
     coinbase::{
-        model::{GetFillsReq, GetOrderRequest, OrderTimeInForce, CancelAfter},
+        model::{CancelAfter, GetFillsReq, GetOrderRequest, OrderTimeInForce},
         Coinbase, CoinbaseCredentials, CoinbaseParameters,
     },
     exchange::Exchange,
@@ -104,7 +104,13 @@ async fn limit_buy() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTC, false)
+        .limit_buy(
+            pair,
+            Decimal::new(1, 3),
+            Decimal::new(1000, 0),
+            OrderTimeInForce::GTC,
+            false,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -117,7 +123,13 @@ async fn limit_sell() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTC, false)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 3),
+            Decimal::new(1000, 0),
+            OrderTimeInForce::GTC,
+            false,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -130,7 +142,13 @@ async fn limit_sell_fok() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::FOK, false)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 3),
+            Decimal::new(1000, 0),
+            OrderTimeInForce::FOK,
+            false,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -143,7 +161,13 @@ async fn limit_sell_ioc() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::IOC, false)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 3),
+            Decimal::new(1000, 0),
+            OrderTimeInForce::IOC,
+            false,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -156,9 +180,15 @@ async fn limit_sell_gtt() {
     let resp = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTT {
-            cancel_after: CancelAfter::Day
-        }, false)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 3),
+            Decimal::new(1000, 0),
+            OrderTimeInForce::GTT {
+                cancel_after: CancelAfter::Day,
+            },
+            false,
+        )
         .await
         .unwrap();
     println!("{:?}", resp);
@@ -197,20 +227,38 @@ async fn cancel_all_orders() {
     exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTC, false)
+        .limit_sell(
+            pair.clone(),
+            Decimal::new(1, 3),
+            Decimal::new(1000, 0),
+            OrderTimeInForce::GTC,
+            false,
+        )
         .await
         .unwrap();
     exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair.clone(), Decimal::new(1, 3), Decimal::new(1000, 0), OrderTimeInForce::GTC, false)
+        .limit_sell(
+            pair.clone(),
+            Decimal::new(1, 3),
+            Decimal::new(1000, 0),
+            OrderTimeInForce::GTC,
+            false,
+        )
         .await
         .unwrap();
 
     exchange
         .inner_client()
         .unwrap()
-        .limit_buy(pair, Decimal::new(2, 2), Decimal::new(2, 2), OrderTimeInForce::GTC, false)
+        .limit_buy(
+            pair,
+            Decimal::new(2, 2),
+            Decimal::new(2, 2),
+            OrderTimeInForce::GTC,
+            false,
+        )
         .await
         .unwrap();
 
@@ -240,7 +288,13 @@ async fn cancel_order() {
     let order = exchange
         .inner_client()
         .unwrap()
-        .limit_sell(pair, Decimal::new(1, 3), Decimal::new(100000, 0), OrderTimeInForce::GTC, false)
+        .limit_sell(
+            pair,
+            Decimal::new(1, 3),
+            Decimal::new(100000, 0),
+            OrderTimeInForce::GTC,
+            false,
+        )
         .await
         .unwrap();
     let resp = exchange

--- a/tests/binance/account.rs
+++ b/tests/binance/account.rs
@@ -8,8 +8,8 @@ use openlimits::{
     exchange::Exchange,
     exchange::{ExchangeAccount, OpenLimits},
     model::{
-        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest, TimeInForce,
-        OpenMarketOrderRequest, TradeHistoryRequest,
+        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest,
+        OpenMarketOrderRequest, TimeInForce, TradeHistoryRequest,
     },
 };
 use rust_decimal::prelude::Decimal;

--- a/tests/binance/account.rs
+++ b/tests/binance/account.rs
@@ -118,8 +118,9 @@ async fn get_order_history() {
 #[tokio::test]
 async fn get_all_open_orders() {
     let exchange = init().await;
+
     let req = OpenLimitOrderRequest {
-        price: Decimal::new(1, 3),
+        price: Decimal::new(5, 3),
         size: Decimal::new(1, 1),
         market_pair: String::from("BNBBTC"),
         time_in_force: TimeInForce::GoodTillCancelled,

--- a/tests/binance/account.rs
+++ b/tests/binance/account.rs
@@ -8,7 +8,7 @@ use openlimits::{
     exchange::Exchange,
     exchange::{ExchangeAccount, OpenLimits},
     model::{
-        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest,
+        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest, TimeInForce,
         OpenMarketOrderRequest, TradeHistoryRequest,
     },
 };
@@ -21,6 +21,7 @@ async fn limit_buy() {
         price: Decimal::new(1, 3),
         size: Decimal::new(1, 1),
         market_pair: String::from("BNBBTC"),
+        time_in_force: TimeInForce::GoodTillCancelled,
     };
     let resp = exchange.limit_buy(&req).await.unwrap();
     println!("{:?}", resp);
@@ -33,6 +34,7 @@ async fn limit_sell() {
         price: Decimal::new(1, 3),
         size: Decimal::new(1, 1),
         market_pair: String::from("BNBBTC"),
+        time_in_force: TimeInForce::GoodTillCancelled,
     };
     let resp = exchange.limit_sell(&req).await.unwrap();
     println!("{:?}", resp);
@@ -67,6 +69,7 @@ async fn cancel_order() {
         price: Decimal::new(5, 3),
         size: Decimal::new(1, 1),
         market_pair: String::from("BNBBTC"),
+        time_in_force: TimeInForce::GoodTillCancelled,
     };
     let order = exchange.limit_sell(&req).await.unwrap();
 
@@ -86,6 +89,7 @@ async fn cancel_all_orders() {
         price: Decimal::new(1, 3),
         size: Decimal::new(1, 1),
         market_pair: String::from("BNBBTC"),
+        time_in_force: TimeInForce::GoodTillCancelled,
     };
     exchange.limit_sell(&req).await.unwrap();
 
@@ -118,6 +122,7 @@ async fn get_all_open_orders() {
         price: Decimal::new(1, 3),
         size: Decimal::new(1, 1),
         market_pair: String::from("BNBBTC"),
+        time_in_force: TimeInForce::GoodTillCancelled,
     };
     exchange.limit_sell(&req).await.unwrap();
 

--- a/tests/coinbase/account.rs
+++ b/tests/coinbase/account.rs
@@ -8,8 +8,8 @@ use openlimits::{
     exchange::Exchange,
     exchange::{ExchangeAccount, OpenLimits},
     model::{
-        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest, TimeInForce,
-        OpenMarketOrderRequest, TradeHistoryRequest,
+        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest,
+        OpenMarketOrderRequest, TimeInForce, TradeHistoryRequest,
     },
 };
 use rust_decimal::prelude::Decimal;

--- a/tests/coinbase/account.rs
+++ b/tests/coinbase/account.rs
@@ -8,7 +8,7 @@ use openlimits::{
     exchange::Exchange,
     exchange::{ExchangeAccount, OpenLimits},
     model::{
-        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest,
+        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest, TimeInForce,
         OpenMarketOrderRequest, TradeHistoryRequest,
     },
 };
@@ -18,6 +18,7 @@ use rust_decimal::prelude::Decimal;
 async fn limit_buy() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::GoodTillCancelled,
         price: Decimal::new(1, 3),
         size: Decimal::new(1, 1),
         market_pair: String::from("ETH-BTC"),
@@ -30,6 +31,7 @@ async fn limit_buy() {
 async fn limit_sell() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::GoodTillCancelled,
         price: Decimal::new(1, 1),
         size: Decimal::new(1, 1),
         market_pair: String::from("ETH-BTC"),
@@ -64,6 +66,7 @@ async fn market_sell() {
 async fn cancel_order() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::GoodTillCancelled,
         price: Decimal::new(1, 1),
         size: Decimal::new(1, 1),
         market_pair: String::from("ETH-BTC"),
@@ -82,6 +85,7 @@ async fn cancel_order() {
 async fn cancel_all_orders() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::GoodTillCancelled,
         price: Decimal::new(1, 1),
         size: Decimal::new(1, 1),
         market_pair: String::from("ETH-BTC"),
@@ -114,6 +118,7 @@ async fn get_order_history() {
 async fn get_all_open_orders() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::GoodTillCancelled,
         price: Decimal::new(1, 1),
         size: Decimal::new(1, 1),
         market_pair: String::from("ETH-BTC"),

--- a/tests/nash/account.rs
+++ b/tests/nash/account.rs
@@ -1,19 +1,19 @@
+use chrono::Duration;
 use dotenv::dotenv;
 use nash_native_client::ws_client::client::Environment;
-use std::env;
-use chrono::Duration;
 use openlimits::{
     exchange::Exchange,
     exchange::{ExchangeAccount, OpenLimits},
     model::{
-        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest, TimeInForce,
-        TradeHistoryRequest,
+        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest,
+        TimeInForce, TradeHistoryRequest,
     },
     nash::Nash,
     nash::NashCredentials,
     nash::NashParameters,
 };
 use rust_decimal::prelude::{Decimal, FromStr};
+use std::env;
 
 #[tokio::test]
 async fn limit_buy() {

--- a/tests/nash/account.rs
+++ b/tests/nash/account.rs
@@ -1,7 +1,7 @@
 use dotenv::dotenv;
 use nash_native_client::ws_client::client::Environment;
 use std::env;
-
+use chrono::Duration;
 use openlimits::{
     exchange::Exchange,
     exchange::{ExchangeAccount, OpenLimits},
@@ -21,7 +21,46 @@ async fn limit_buy() {
     let req = OpenLimitOrderRequest {
         time_in_force: TimeInForce::GoodTillCancelled,
         price: Decimal::from_str("414.46").unwrap(),
-        size: Decimal::from_str("0.0168").unwrap(),
+        size: Decimal::from_str("0.10000").unwrap(),
+        market_pair: String::from("eth_usdc"),
+    };
+    let resp = exchange.limit_buy(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn limit_buy_ioc() {
+    let exchange = init().await;
+    let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::ImmediateOrCancelled,
+        price: Decimal::from_str("414.46").unwrap(),
+        size: Decimal::from_str("0.10000").unwrap(),
+        market_pair: String::from("eth_usdc"),
+    };
+    let resp = exchange.limit_buy(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn limit_buy_fok() {
+    let exchange = init().await;
+    let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::FillOrKill,
+        price: Decimal::from_str("414.46").unwrap(),
+        size: Decimal::from_str("0.10000").unwrap(),
+        market_pair: String::from("eth_usdc"),
+    };
+    let resp = exchange.limit_buy(&req).await.unwrap();
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn limit_buy_ggt() {
+    let exchange = init().await;
+    let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::GoodTillTime(Duration::hours(2)),
+        price: Decimal::from_str("414.46").unwrap(),
+        size: Decimal::from_str("0.10000").unwrap(),
         market_pair: String::from("eth_usdc"),
     };
     let resp = exchange.limit_buy(&req).await.unwrap();
@@ -33,9 +72,9 @@ async fn limit_sell() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
         time_in_force: TimeInForce::GoodTillCancelled,
-        price: Decimal::new(1, 1),
-        size: Decimal::new(2, 2),
-        market_pair: String::from("eth_btc"),
+        price: Decimal::from_str("414.46").unwrap(),
+        size: Decimal::from_str("0.10000").unwrap(),
+        market_pair: String::from("eth_usdc"),
     };
     let resp = exchange.limit_sell(&req).await.unwrap();
     println!("{:?}", resp);
@@ -46,11 +85,11 @@ async fn cancel_order() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
         time_in_force: TimeInForce::GoodTillCancelled,
-        price: Decimal::new(1, 1),
-        size: Decimal::new(2, 2),
-        market_pair: String::from("eth_btc"),
+        price: Decimal::from_str("200.46").unwrap(),
+        size: Decimal::from_str("0.10000").unwrap(),
+        market_pair: String::from("eth_usdc"),
     };
-    let order = exchange.limit_sell(&req).await.unwrap();
+    let order = exchange.limit_buy(&req).await.unwrap();
 
     let req = CancelOrderRequest {
         id: order.id,
@@ -65,11 +104,10 @@ async fn cancel_all_orders() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
         time_in_force: TimeInForce::GoodTillCancelled,
-        price: Decimal::new(1, 1),
-        size: Decimal::new(2, 2),
-        market_pair: String::from("eth_btc"),
+        price: Decimal::from_str("200.46").unwrap(),
+        size: Decimal::from_str("0.10000").unwrap(),
+        market_pair: String::from("eth_usdc"),
     };
-    exchange.limit_sell(&req).await.unwrap();
 
     exchange.limit_sell(&req).await.unwrap();
 
@@ -135,8 +173,8 @@ async fn init() -> Nash {
             secret: env::var("NASH_API_SECRET").unwrap(),
             session: env::var("NASH_API_KEY").unwrap(),
         }),
-        environment: Environment::Production,
-        client_id: 1234,
+        environment: Environment::Sandbox,
+        client_id: 1,
         timeout: 100000,
     };
 

--- a/tests/nash/account.rs
+++ b/tests/nash/account.rs
@@ -6,7 +6,7 @@ use openlimits::{
     exchange::Exchange,
     exchange::{ExchangeAccount, OpenLimits},
     model::{
-        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest,
+        CancelAllOrdersRequest, CancelOrderRequest, GetOrderHistoryRequest, OpenLimitOrderRequest, TimeInForce,
         TradeHistoryRequest,
     },
     nash::Nash,
@@ -19,7 +19,8 @@ use rust_decimal::prelude::{Decimal, FromStr};
 async fn limit_buy() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
-        price: Decimal::from_str("300.46").unwrap(),
+        time_in_force: TimeInForce::GoodTillCancelled,
+        price: Decimal::from_str("414.46").unwrap(),
         size: Decimal::from_str("0.0168").unwrap(),
         market_pair: String::from("eth_usdc"),
     };
@@ -31,6 +32,7 @@ async fn limit_buy() {
 async fn limit_sell() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::GoodTillCancelled,
         price: Decimal::new(1, 1),
         size: Decimal::new(2, 2),
         market_pair: String::from("eth_btc"),
@@ -43,6 +45,7 @@ async fn limit_sell() {
 async fn cancel_order() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::GoodTillCancelled,
         price: Decimal::new(1, 1),
         size: Decimal::new(2, 2),
         market_pair: String::from("eth_btc"),
@@ -61,6 +64,7 @@ async fn cancel_order() {
 async fn cancel_all_orders() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
+        time_in_force: TimeInForce::GoodTillCancelled,
         price: Decimal::new(1, 1),
         size: Decimal::new(2, 2),
         market_pair: String::from("eth_btc"),
@@ -93,6 +97,7 @@ async fn get_order_history() {
 // async fn get_all_open_orders() {
 //     let mut exchange = init().await;
 //     let req = OpenLimitOrderRequest {
+//         time_in_force: TimeInForce::GoodTillCancelled,
 //         price: Decimal::new(1, 1),
 //         size: Decimal::new(2, 2),
 //         market_pair: String::from("eth_btc"),

--- a/tests/nash/market.rs
+++ b/tests/nash/market.rs
@@ -87,8 +87,8 @@ async fn init() -> Nash {
             session: env::var("NASH_API_KEY").unwrap(),
         }),
         environment: Environment::Sandbox,
-        client_id: 1234,
-        timeout: 100000,
+        client_id: 1,
+        timeout: 1000,
     };
 
     OpenLimits::instantiate(parameters).await

--- a/tests/nash/websocket.rs
+++ b/tests/nash/websocket.rs
@@ -33,7 +33,7 @@ async fn init() -> OpenLimitsWs<NashStream> {
         &env::var("NASH_API_SECRET").unwrap(),
         &env::var("NASH_API_KEY").unwrap(),
         1234,
-        false,
+        true,
         10000,
     )
     .await;


### PR DESCRIPTION
This PR adds support for TimeInForce. Different exchanges have different ways of supporting this.

- Nash supports GTC, IOC, FOK and GTT. GTT supports any timestamp as parameter.
- Coinbase supports GTC, IOC, FOK, GTT. GTT only supports three durations: 1 Minute, 1 Hour and 1 day.
- Binance only supports GTC, IOC, FOK.

I feel the most cross exchange way of supporting this would be to represent the GTC, IOC and FOK as normal enums, and GTT as a duration. This would fit the Coinbase model, and for nash the timestamp can be converted by doing a simple `current_time + duration` calculation.

```
pub enum TimeInForce {
    GoodTillCancelled,
    ImmediateOrCancelled,
    FillOrKill,
    // Representing 'good till time' as a duration works for both Nash and Coinbase
    GoodTillTime(Duration),
}
```

This PR also fixes two bugs I found while testing the Coinbase and Binance implementations. Our naivetimestamp deserialization code sometimes fails if the timestamp lands on a whole milisecond. Our Binance client had an endless loop in the `get_all_open_orders` call.

closes #104