### PR TITLE
Remove panic for nash/binance implementation so clients can handle socket errors

### DIFF
--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -544,7 +544,10 @@ impl ExchangeWs for BinanceWebsocket {
         BinanceWebsocket::subscribe(self, subscription.into()).await
     }
     fn parse_message(&self, message: Self::Item) -> Result<OpenLimitsWebsocketMessage> {
-        Ok(message?.into())
+        match message? {
+             model::websocket::BinanceWebsocketMessage::Close => Err(OpenLimitError::SocketError()),
+             msg => Ok(msg.into())
+        }
     }
 }
 impl From<Subscription> for model::websocket::Subscription {

--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -545,8 +545,8 @@ impl ExchangeWs for BinanceWebsocket {
     }
     fn parse_message(&self, message: Self::Item) -> Result<OpenLimitsWebsocketMessage> {
         match message? {
-             model::websocket::BinanceWebsocketMessage::Close => Err(OpenLimitError::SocketError()),
-             msg => Ok(msg.into())
+            model::websocket::BinanceWebsocketMessage::Close => Err(OpenLimitError::SocketError()),
+            msg => Ok(msg.into()),
         }
     }
 }

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -728,7 +728,7 @@ impl ExchangeWs for NashStream {
                     }
                 }
             },
-            Err(err) =>  Err(OpenLimitError::NashProtocolError(err))
+            Err(_) =>  Err(OpenLimitError::SocketError())
         }
     }
 }

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -708,13 +708,28 @@ impl ExchangeWs for NashStream {
     }
     async fn subscribe(&mut self, subscription: Subscription) -> Result<()> {
         let sub: nash_protocol::protocol::subscriptions::SubscriptionRequest = subscription.into();
-        let _stream = Client::subscribe_protocol(&self.client, sub).await.unwrap();
+        let _stream = Client::subscribe_protocol(&self.client, sub).await;
+        let _stream = _stream.map_err(|e| Err(OpenLimitError::NashProtocolError(e)));
+        if _stream.is_err() {
+            return _stream.unwrap_err()
+        }
 
         Ok(())
     }
 
     fn parse_message(&self, message: Self::Item) -> Result<OpenLimitsWebsocketMessage> {
-        Ok(message.unwrap().consume_response().unwrap().into())
+        match message {
+            Ok(msg) => {
+                match msg {
+                    ResponseOrError::Response(resp) => Ok(resp.data.into()),
+                    ResponseOrError::Error(resp) => {
+                        let f = resp.errors.iter().map(|f|f.message.clone()).collect::<Vec<String>>().join("\n");
+                        Err(OpenLimitError::NotParsableResponse(String::from(f)))
+                    }
+                }
+            },
+            Err(err) =>  Err(OpenLimitError::NashProtocolError(err))
+        }
     }
 }
 

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -711,7 +711,7 @@ impl ExchangeWs for NashStream {
         let _stream = Client::subscribe_protocol(&self.client, sub).await;
         let _stream = _stream.map_err(|e| Err(OpenLimitError::NashProtocolError(e)));
         if _stream.is_err() {
-            return _stream.unwrap_err()
+            return _stream.unwrap_err();
         }
 
         Ok(())
@@ -719,16 +719,19 @@ impl ExchangeWs for NashStream {
 
     fn parse_message(&self, message: Self::Item) -> Result<OpenLimitsWebsocketMessage> {
         match message {
-            Ok(msg) => {
-                match msg {
-                    ResponseOrError::Response(resp) => Ok(resp.data.into()),
-                    ResponseOrError::Error(resp) => {
-                        let f = resp.errors.iter().map(|f|f.message.clone()).collect::<Vec<String>>().join("\n");
-                        Err(OpenLimitError::NotParsableResponse(String::from(f)))
-                    }
+            Ok(msg) => match msg {
+                ResponseOrError::Response(resp) => Ok(resp.data.into()),
+                ResponseOrError::Error(resp) => {
+                    let f = resp
+                        .errors
+                        .iter()
+                        .map(|f| f.message.clone())
+                        .collect::<Vec<String>>()
+                        .join("\n");
+                    Err(OpenLimitError::NotParsableResponse(String::from(f)))
                 }
             },
-            Err(_) =>  Err(OpenLimitError::SocketError())
+            Err(_) => Err(OpenLimitError::SocketError()),
         }
     }
 }


### PR DESCRIPTION
Changes how nash-protocol messages are handled to avoid a panic in openlimits.

This allows clients to handle the error instead of getting a panic!.