### PR TITLE
Add a few extra data fields to market, order and ticker

### DIFF
--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -135,6 +135,8 @@ impl ExchangeInfoRetrieval for Binance {
                         symbol: symbol.symbol,
                         base_increment: *lot_size,
                         quote_increment: *tick_size,
+                        min_base_trade_size: None,
+                        min_quote_trade_size: None,
                     }
                 })
                 .collect()
@@ -356,8 +358,9 @@ impl From<model::Order> for Order {
             order_type,
             side: order.side.into(),
             status: order.status.into(),
-            price: Some(order.price),
             size: order.orig_qty,
+            price: Some(order.price),
+            remaining: Some(order.orig_qty - order.executed_qty),
         }
     }
 }
@@ -405,7 +408,8 @@ impl From<model::TradeHistory> for Trade {
 impl From<model::SymbolPrice> for Ticker {
     fn from(ticker: model::SymbolPrice) -> Self {
         Self {
-            price: ticker.price,
+            price: Some(ticker.price),
+            price_24h: None,
         }
     }
 }

--- a/src/binance/model/mod.rs
+++ b/src/binance/model/mod.rs
@@ -59,7 +59,8 @@ pub struct Order {
     pub price: Decimal,
     #[serde(with = "string_to_decimal")]
     pub orig_qty: Decimal,
-    pub executed_qty: String,
+    #[serde(with = "string_to_decimal")]
+    pub executed_qty: Decimal,
     pub status: OrderStatus,
     pub time_in_force: String,
     #[serde(rename = "type")]

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -106,6 +106,8 @@ impl ExchangeInfoRetrieval for Coinbase {
                     quote: product.quote_currency,
                     base_increment: product.base_increment,
                     quote_increment: product.quote_increment,
+                    min_base_trade_size: None,
+                    min_quote_trade_size: None
                 })
                 .collect()
         })
@@ -183,11 +185,12 @@ impl From<model::Order> for Order {
             market_pair: order.product_id,
             client_order_id: None,
             created_at: Some((order.created_at.timestamp_millis()) as u64),
-            price,
-            size,
+            order_type,
             side: order.side.into(),
             status: order.status.into(),
-            order_type,
+            size,
+            price,
+            remaining: Some(size - order.filled_size),
         }
     }
 }
@@ -338,7 +341,8 @@ impl From<model::Fill> for Trade {
 impl From<model::Ticker> for Ticker {
     fn from(ticker: model::Ticker) -> Self {
         Self {
-            price: ticker.price,
+            price: Some(ticker.price),
+            price_24h: None,
         }
     }
 }

--- a/src/exchange_info.rs
+++ b/src/exchange_info.rs
@@ -25,6 +25,8 @@ pub struct MarketPair {
     pub symbol: String,
     pub base_increment: Decimal,
     pub quote_increment: Decimal,
+    pub min_base_trade_size: Option<Decimal>,
+    pub min_quote_trade_size: Option<Decimal>,
 }
 
 #[derive(Debug)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -123,6 +123,7 @@ pub struct Order {
     pub status: OrderStatus,
     pub size: Decimal,
     pub price: Option<Decimal>,
+    pub remaining: Option<Decimal>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Constructor, Debug)]
@@ -197,7 +198,8 @@ pub struct Balance {
 
 #[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]
 pub struct Ticker {
-    pub price: Decimal,
+    pub price: Option<Decimal>,
+    pub price_24h: Option<Decimal>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Constructor, Debug, PartialEq)]


### PR DESCRIPTION
- added a remaining amount field to Order
- added min trade sizes to MarketPair
- added a last day price field to the ticker. we plan to derive this from our trade db in the future, but I thought it wouldn't hurt for now

corresponding nash-rust PR https://github.com/nash-io/nash-rust/pull/24