### PR TITLE
Add buyer_order_id and seller_order_id in Trade

### DIFF
--- a/src/binance/mod.rs
+++ b/src/binance/mod.rs
@@ -322,7 +322,8 @@ impl From<model::websocket::TradeMessage> for Vec<Trade> {
     fn from(trade_message: model::websocket::TradeMessage) -> Self {
         vec![Trade {
             id: trade_message.trade_id.to_string(),
-            order_id: trade_message.buyer_order_id.to_string(),
+            buyer_order_id: Some(trade_message.buyer_order_id.to_string()),
+            seller_order_id: Some(trade_message.buyer_order_id.to_string()),
             market_pair: trade_message.symbol,
             price: trade_message.price,
             qty: trade_message.qty,
@@ -341,7 +342,8 @@ impl From<TradeMessage> for Trade {
     fn from(trade: TradeMessage) -> Self {
         Self {
             id: trade.trade_id.to_string(),
-            order_id: trade.buyer_order_id.to_string(),
+            buyer_order_id: Some(trade.buyer_order_id.to_string()),
+            seller_order_id: Some(trade.seller_order_id.to_string()),
             market_pair: trade.symbol,
             price: trade.price,
             qty: trade.qty,
@@ -421,9 +423,14 @@ impl From<model::Balance> for Balance {
 
 impl From<model::TradeHistory> for Trade {
     fn from(trade_history: model::TradeHistory) -> Self {
+        let (buyer_order_id, seller_order_id) = match trade_history.is_buyer {
+            true => (Some(trade_history.order_id.to_string()), None),
+            false => (None, Some(trade_history.order_id.to_string())),
+        };
         Self {
             id: trade_history.id.to_string(),
-            order_id: trade_history.order_id.to_string(),
+            buyer_order_id: buyer_order_id,
+            seller_order_id: seller_order_id,
             market_pair: trade_history.symbol,
             price: trade_history.price,
             qty: trade_history.qty,

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -323,9 +323,15 @@ impl From<model::Account> for Balance {
 
 impl From<model::Fill> for Trade {
     fn from(fill: model::Fill) -> Self {
+        let (buyer_order_id, seller_order_id) = match fill.side.as_str() {
+            "buy" => (Some(fill.order_id), None),
+            _ => (None, Some(fill.order_id)),
+        };
+
         Self {
             id: fill.trade_id.to_string(),
-            order_id: fill.order_id,
+            buyer_order_id: buyer_order_id,
+            seller_order_id: seller_order_id,
             market_pair: fill.product_id,
             price: fill.price,
             qty: fill.size,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -168,7 +168,8 @@ pub struct OrderCanceled {
 #[derive(Serialize, Deserialize, Clone, Constructor, Debug)]
 pub struct Trade {
     pub id: String,
-    pub order_id: String,
+    pub buyer_order_id: Option<String>,
+    pub seller_order_id: Option<String>,
     pub market_pair: String,
     pub price: Decimal,
     pub qty: Decimal,

--- a/src/model/python.rs
+++ b/src/model/python.rs
@@ -508,8 +508,17 @@ impl ToPyObject for Trade {
             .set_item("qty", self.qty.to_string())
             .expect("Couldn't set qty.");
         inner_dict
-            .set_item("order_id", self.order_id.to_string())
-            .expect("Couldn't set order_id.");
+            .set_item(
+                "buyer_order_id",
+                self.buyer_order_id.clone().map(|id| id.to_string()),
+            )
+            .expect("Couldn't set buyer_order_id.");
+        inner_dict
+            .set_item(
+                "seller_order_id",
+                self.seller_order_id.clone().map(|id| id.to_string()),
+            )
+            .expect("Couldn't set seller_order_id.");
         inner_dict
             .set_item("side", self.side.clone())
             .expect("Couldn't set side.");


### PR DESCRIPTION
Trade by definition has two sides - buyer and seller, so it has to contain both buyer order id and seller order id. Most of the exchanges (including binance and nash) report this information.

There's also 'own trade' when considered in the view of interfaces like 'own trade history', in this case only one order id relevant to user is usually reported.

As openlimits now mixes up 'all trades' and 'own trades' in one data type I had to make buyer_order_id and seller_order_id optional and fill them if the information is available.