### PR TITLE
Allow openlimits users to choose between num_bigint and gmp libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,6 @@ tungstenite = "0.11.0"
 sha2 = "0.9.1"
 url = "2.1.1"
 derive_more = "0.99"
-nash-protocol = { version = "=0.1.17", default-features = false, features = ["rustcrypto", "num_bigint"] }
-nash-native-client = { version = "=0.1.9", default-features = false, features = ["rustcrypto", "num_bigint"] }
+nash-protocol = { version = "=0.1.17", default-features = false, features = ["rustcrypto", "rust_gmp"] }
+nash-native-client = { version = "=0.1.9", default-features = false, features = ["rustcrypto", "rust_gmp"] }
 pyo3 = { version = "0.12.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openlimits"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["steffel <2143646+steffenix@users.noreply.github.com>", "Ethan Fast <ethan@nash.io>"]
 edition = "2018"
 description = "A open source Rust high performance cryptocurrency trading API with support for multiple exchanges and language wrappers. Focused in safety, correctness and speed."
@@ -12,6 +12,9 @@ keywords = ["cryptocurrency", "exchange", "openlimits", "api"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["rust_gmp"]
+rust_gmp = ["nash-protocol/rust_gmp", "nash-native-client/rust_gmp"]
+num_bigint = ["nash-protocol/num_bigint", "nash-native-client/num_bigint"]
 python = ["pyo3"]
 
 [dependencies]
@@ -36,6 +39,6 @@ tungstenite = "0.11.0"
 sha2 = "0.9.1"
 url = "2.1.1"
 derive_more = "0.99"
-nash-protocol = { version = "=0.1.17", default-features = false, features = ["rustcrypto", "rust_gmp"] }
-nash-native-client = { version = "=0.1.9", default-features = false, features = ["rustcrypto", "rust_gmp"] }
+nash-protocol = { version = "=0.1.17", default-features = false, features = ["rustcrypto"] }
+nash-native-client = { version = "=0.1.9", default-features = false, features = ["rustcrypto"] }
 pyo3 = { version = "0.12.3", optional = true }

--- a/tests/nash/account.rs
+++ b/tests/nash/account.rs
@@ -73,7 +73,7 @@ async fn limit_buy_ggt() {
     let req = OpenLimitOrderRequest {
         time_in_force: TimeInForce::GoodTillTime(Duration::hours(2)),
         price: Decimal::from_str("414.46").expect("Couldn't parse string."),
-        size: Decimal::from_str("0.10000").expect("Couldn't parse string."),
+        size: Decimal::from_str("0.02000").expect("Couldn't parse string."),
         market_pair: String::from("eth_usdc"),
         post_only: false,
     };
@@ -116,9 +116,9 @@ async fn market_sell() {
 async fn limit_sell() {
     let exchange = init().await;
     let req = OpenLimitOrderRequest {
-        time_in_force: TimeInForce::GoodTillCancelled,
-        price: Decimal::from_str("414.46").expect("Couldn't parse string."),
-        size: Decimal::from_str("0.10000").expect("Couldn't parse string."),
+        time_in_force: TimeInForce::GoodTillTime(Duration::hours(2)),
+        price: Decimal::from_str("800.46").expect("Couldn't parse string."),
+        size: Decimal::from_str("0.02").expect("Couldn't parse string."),
         market_pair: String::from("eth_usdc"),
         post_only: false,
     };
@@ -246,7 +246,7 @@ async fn init() -> Nash {
             secret: env::var("NASH_API_SECRET").expect("Couldn't get environment variable."),
             session: env::var("NASH_API_KEY").expect("Couldn't get environment variable."),
         }),
-        environment: Environment::Sandbox,
+        environment: Environment::Production,
         client_id: 1,
         timeout: 100000,
     };

--- a/tests/nash/account.rs
+++ b/tests/nash/account.rs
@@ -246,7 +246,7 @@ async fn init() -> Nash {
             secret: env::var("NASH_API_SECRET").expect("Couldn't get environment variable."),
             session: env::var("NASH_API_KEY").expect("Couldn't get environment variable."),
         }),
-        environment: Environment::Production,
+        environment: Environment::Sandbox,
         client_id: 1,
         timeout: 100000,
     };


### PR DESCRIPTION
Set the default to `rust_gmp` as that speeds up development in a test environment (without `--release`) by a considerable amount. But users can override.