### PR TITLE
Fix build using latest nash protocol version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ tungstenite = "0.12"
 sha2 = "0.9.1"
 url = "2.1.1"
 derive_more = "0.99"
-nash-protocol = { version = "=0.1.24", default-features = false, features = ["rustcrypto"] }
-nash-native-client = { version = "=0.1.18", default-features = false, features = ["rustcrypto"] }
+nash-protocol = { version = "=0.1.26", default-features = false, features = ["rustcrypto"] }
+nash-native-client = { version = "=0.1.21", default-features = false, features = ["rustcrypto"] }
 pyo3 = { version = "0.12.3", optional = true }
 
 #nash-protocol = { path = "../nash-rust/nash-protocol", default-features = false, features = ["rustcrypto"]}

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -63,12 +63,14 @@ impl Clone for NashParameters {
 }
 
 async fn client_from_params_failable(params: NashParameters) -> Result<Client> {
+    let turn_off_sign_states = params.sign_states_loop_interval.is_none();
     let client = match params.credentials {
         Some(credentials) => {
             Client::from_keys(
                 &credentials.secret,
                 &credentials.session,
                 params.affiliate_code,
+                turn_off_sign_states,
                 params.client_id,
                 params.environment,
                 params.timeout,
@@ -78,8 +80,9 @@ async fn client_from_params_failable(params: NashParameters) -> Result<Client> {
         None => {
             Client::from_keys_path(
                 None,
-                params.client_id,
                 None,
+                turn_off_sign_states,
+                params.client_id,
                 params.environment,
                 params.timeout,
             )
@@ -88,7 +91,7 @@ async fn client_from_params_failable(params: NashParameters) -> Result<Client> {
     };
 
     if let Some(interval) = params.sign_states_loop_interval {
-        client.start_background_state_signing(interval);
+        client.start_background_sign_states_loop(interval);
     }
 
     Ok(client)


### PR DESCRIPTION
Current master of openlimit cannot build (error in similar types between bitvec and funty).

Using recent version of nash protocol, the issue goes away. This need a small change to nash exchange interface though.