### PR TITLE
Add get_account_fees()

### DIFF
--- a/src/any_exchange.rs
+++ b/src/any_exchange.rs
@@ -19,10 +19,10 @@ use crate::{
 };
 use crate::{
     model::{
-        websocket::Subscription, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
-        GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
-        GetPriceTickerRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order,
-        OrderBookRequest, OrderBookResponse, OrderCanceled, Paginator, Ticker, Trade,
+        websocket::Subscription, AccountFees, Balance, CancelAllOrdersRequest, CancelOrderRequest,
+        Candle, GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest,
+        GetOrderRequest, GetPriceTickerRequest, OpenLimitOrderRequest, OpenMarketOrderRequest,
+        Order, OrderBookRequest, OrderBookResponse, OrderCanceled, Paginator, Ticker, Trade,
         TradeHistoryRequest,
     },
     shared::Result,
@@ -163,6 +163,13 @@ impl ExchangeAccount for AnyExchange {
             Self::Nash(nash) => nash.get_account_balances(paginator).await,
             Self::Binance(binance) => binance.get_account_balances(paginator).await,
             Self::Coinbase(coinbase) => coinbase.get_account_balances(paginator).await,
+        }
+    }
+    async fn get_account_fees(&self) -> Result<AccountFees> {
+        match self {
+            Self::Nash(nash) => nash.get_account_fees().await,
+            Self::Binance(binance) => binance.get_account_fees().await,
+            Self::Coinbase(coinbase) => coinbase.get_account_fees().await,
         }
     }
     async fn get_order(&self, req: &GetOrderRequest) -> Result<Order> {

--- a/src/binance/model/mod.rs
+++ b/src/binance/model/mod.rs
@@ -1,5 +1,5 @@
 pub mod websocket;
-use crate::shared::{string_to_decimal, string_to_opt_decimal};
+use crate::shared::{f32_to_decimal, string_to_decimal, string_to_opt_decimal};
 use serde::{Deserialize, Serialize};
 
 use rust_decimal::prelude::Decimal;
@@ -30,8 +30,10 @@ pub struct ExchangeInformation {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountInformation {
-    pub maker_commission: f32,
-    pub taker_commission: f32,
+    #[serde(with = "f32_to_decimal")]
+    pub maker_commission: Decimal,
+    #[serde(with = "f32_to_decimal")]
+    pub taker_commission: Decimal,
     pub buyer_commission: f32,
     pub seller_commission: f32,
     pub can_trade: bool,

--- a/src/coinbase/client/account.rs
+++ b/src/coinbase/client/account.rs
@@ -1,7 +1,7 @@
 use super::BaseClient;
 use crate::{
     coinbase::model::{
-        Account, CancelAllOrders, CancelOrder, Fill, GetFillsReq, GetOrderRequest, Order,
+        Account, CancelAllOrders, CancelOrder, Fees, Fill, GetFillsReq, GetOrderRequest, Order,
         OrderRequest, OrderRequestMarketType, OrderRequestType, OrderSide, OrderTimeInForce,
         Paginator,
     },
@@ -14,6 +14,10 @@ use rust_decimal::prelude::*;
 impl BaseClient {
     pub async fn get_account(&self, paginator: Option<&Paginator>) -> Result<Vec<Account>> {
         self.transport.signed_get("/accounts", paginator).await
+    }
+
+    pub async fn get_fees(&self) -> Result<Fees> {
+        self.transport.signed_get::<_, ()>("/fees", None).await
     }
 
     pub async fn get_orders(&self, params: Option<&GetOrderRequest>) -> Result<Vec<Order>> {

--- a/src/coinbase/mod.rs
+++ b/src/coinbase/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     exchange_info::ExchangeInfo,
     exchange_info::{ExchangeInfoRetrieval, MarketPair, MarketPairHandle},
     model::{
-        AskBid, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
+        AccountFees, AskBid, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
         GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
         GetPriceTickerRequest, Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest,
         Order, OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, OrderType,
@@ -160,6 +160,15 @@ impl From<model::Book<model::BookRecordL2>> for OrderBookResponse {
     }
 }
 
+impl From<model::Fees> for AccountFees {
+    fn from(fees: model::Fees) -> Self {
+        Self {
+            maker: fees.maker_fee_rate,
+            taker: fees.taker_fee_rate,
+        }
+    }
+}
+
 impl From<model::BookRecordL2> for AskBid {
     fn from(bids: model::BookRecordL2) -> Self {
         Self {
@@ -291,6 +300,10 @@ impl ExchangeAccount for Coinbase {
             .get_account(paginator.as_ref())
             .await
             .map(|v| v.into_iter().map(Into::into).collect())
+    }
+
+    async fn get_account_fees(&self) -> Result<AccountFees> {
+        self.client.get_fees().await.map(Into::into)
     }
 
     async fn get_order(&self, req: &GetOrderRequest) -> Result<Order> {

--- a/src/coinbase/model/mod.rs
+++ b/src/coinbase/model/mod.rs
@@ -44,6 +44,16 @@ pub struct Account {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Fees {
+    #[serde(with = "string_to_decimal")]
+    pub maker_fee_rate: Decimal,
+    #[serde(with = "string_to_decimal")]
+    pub taker_fee_rate: Decimal,
+    #[serde(with = "string_to_decimal")]
+    pub usd_volume: Decimal,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Candle {
     pub time: u64,
     pub low: Decimal,

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -3,10 +3,11 @@ use async_trait::async_trait;
 use crate::exchange_info::ExchangeInfoRetrieval;
 use crate::{
     model::{
-        Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle, GetHistoricRatesRequest,
-        GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest, GetPriceTickerRequest,
-        OpenLimitOrderRequest, OpenMarketOrderRequest, Order, OrderBookRequest, OrderBookResponse,
-        OrderCanceled, Paginator, Ticker, Trade, TradeHistoryRequest,
+        AccountFees, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
+        GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
+        GetPriceTickerRequest, OpenLimitOrderRequest, OpenMarketOrderRequest, Order,
+        OrderBookRequest, OrderBookResponse, OrderCanceled, Paginator, Ticker, Trade,
+        TradeHistoryRequest,
     },
     shared::Result,
 };
@@ -47,5 +48,6 @@ pub trait ExchangeAccount {
     async fn get_order_history(&self, req: &GetOrderHistoryRequest) -> Result<Vec<Order>>;
     async fn get_trade_history(&self, req: &TradeHistoryRequest) -> Result<Vec<Trade>>;
     async fn get_account_balances(&self, paginator: Option<Paginator>) -> Result<Vec<Balance>>;
+    async fn get_account_fees(&self) -> Result<AccountFees>;
     async fn get_order(&self, req: &GetOrderRequest) -> Result<Order>;
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -187,6 +187,12 @@ pub enum Liquidity {
     Taker,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AccountFees {
+    pub maker: Decimal,
+    pub taker: Decimal,
+}
+
 #[derive(Serialize, Deserialize, Default)]
 pub struct TradeHistoryRequest {
     pub market_pair: Option<String>,

--- a/src/nash/mod.rs
+++ b/src/nash/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     model::websocket::OpenLimitsWebSocketMessage,
     model::{
         websocket::{Subscription, WebSocketResponse},
-        AskBid, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
+        AccountFees, AskBid, Balance, CancelAllOrdersRequest, CancelOrderRequest, Candle,
         GetHistoricRatesRequest, GetHistoricTradesRequest, GetOrderHistoryRequest, GetOrderRequest,
         GetPriceTickerRequest, Interval, Liquidity, OpenLimitOrderRequest, OpenMarketOrderRequest,
         Order, OrderBookRequest, OrderBookResponse, OrderCanceled, OrderStatus, OrderType,
@@ -215,6 +215,14 @@ impl ExchangeAccount for Nash {
         }
 
         Ok(balances)
+    }
+
+    async fn get_account_fees(&self) -> Result<AccountFees> {
+        Err(OpenLimitsError::MissingImplementation(
+            MissingImplementationContent {
+                message: "'get_account_fees' for nash is not implemented".to_string(),
+            },
+        ))
     }
 
     async fn get_all_open_orders(&self) -> Result<Vec<Order>> {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,5 +1,37 @@
 pub type Result<T> = std::result::Result<T, crate::errors::OpenLimitsError>;
 
+pub mod f32_to_decimal {
+    use std::fmt;
+
+    use rust_decimal::prelude::*;
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: fmt::Display,
+        S: Serializer,
+    {
+        serializer.collect_str(value)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Decimal, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum F32ToDecimal {
+            F32(f32),
+        }
+
+        let F32ToDecimal::F32(val) = F32ToDecimal::deserialize(deserializer)?;
+        Decimal::from_f32(val).ok_or(de::Error::custom(format!(
+            "Failed to convert {} to Decimal",
+            val
+        )))
+    }
+}
+
 pub mod string_to_decimal {
     use std::fmt;
 

--- a/tests/binance/account.rs
+++ b/tests/binance/account.rs
@@ -1,6 +1,8 @@
 use dotenv::dotenv;
 use std::env;
 
+use openlimits::exchange::ExchangeMarketData;
+use openlimits::model::GetPriceTickerRequest;
 use openlimits::{
     binance::Binance,
     binance::BinanceCredentials,
@@ -12,8 +14,6 @@ use openlimits::{
     },
 };
 use rust_decimal::prelude::Decimal;
-use openlimits::exchange::ExchangeMarketData;
-use openlimits::model::GetPriceTickerRequest;
 
 #[tokio::test]
 #[ignore]
@@ -179,8 +179,13 @@ async fn get_order_history() {
 }
 
 async fn get_price(exchange: &Binance, pair: &str) -> Decimal {
-    let get_price_ticker_request = GetPriceTickerRequest { market_pair: pair.to_string() };
-    let ticker = exchange.get_price_ticker(&get_price_ticker_request).await.expect("Couldn't get ticker.");
+    let get_price_ticker_request = GetPriceTickerRequest {
+        market_pair: pair.to_string(),
+    };
+    let ticker = exchange
+        .get_price_ticker(&get_price_ticker_request)
+        .await
+        .expect("Couldn't get ticker.");
     ticker.price.expect("Couldn't get price.")
 }
 
@@ -214,7 +219,18 @@ async fn get_account_balances() {
     let resp = exchange
         .get_account_balances(None)
         .await
-        .expect("Couldn't get acount balances.");
+        .expect("Couldn't get account balances.");
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
+async fn get_account_fees() {
+    let exchange = init().await;
+
+    let resp = exchange
+        .get_account_fees()
+        .await
+        .expect("couldn't get account fees.");
     println!("{:?}", resp);
 }
 

--- a/tests/coinbase/account.rs
+++ b/tests/coinbase/account.rs
@@ -202,6 +202,17 @@ async fn get_account_balances() {
 }
 
 #[tokio::test]
+async fn get_account_fees() {
+    let exchange = init().await;
+
+    let resp = exchange
+        .get_account_fees()
+        .await
+        .expect("couldn't get account fees.");
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
 async fn get_trade_history() {
     let exchange = init().await;
     let req = TradeHistoryRequest {

--- a/tests/nash/account.rs
+++ b/tests/nash/account.rs
@@ -233,6 +233,17 @@ async fn get_account_balances() {
 }
 
 #[tokio::test]
+async fn get_account_fees() {
+    let exchange = init().await;
+
+    let resp = exchange
+        .get_account_fees()
+        .await
+        .expect("couldn't get account fees.");
+    println!("{:?}", resp);
+}
+
+#[tokio::test]
 async fn get_trade_history() {
     let exchange = init().await;
     let req = TradeHistoryRequest {


### PR DESCRIPTION
#172 

Implemented for Binance and Coinbase. Didn't find Nash API docs, so for now it will return a not implemented error. I can implement it for Nash if anyone post a link to relevant docs.

I tested this in my personal project for both exchanges (not via `cargo test`). Not sure how to set up the tests - a lot of tests (including the new tests) failed after adding `.env` file with my sandbox credentials for Binance.

I'm new to both rust and this project. I'll happily make an required changes.

Note: there are 2 unrelated changes in binance account tests:
* VS code insisted to format this line:  `let get_price_ticker_request = GetPriceTickerRequest {` - it is the only place, so it doesn't seem like my editor config is different than what you guys are using - it may actually be a good change.
* Spelling correction at `.expect("Couldn't get acount balances.");`